### PR TITLE
[WIP] Css units: rem, vh, vw

### DIFF
--- a/haxe/ui/Toolkit.hx
+++ b/haxe/ui/Toolkit.hx
@@ -155,7 +155,19 @@ class Toolkit {
 
         return component;
     }
-    
+
+    public static var pixelsPerRem(default, set):Int = 16;
+    private static function set_pixelsPerRem(value:Int):Int {
+        if(pixelsPerRem == value) {
+            return value;
+        }
+
+        pixelsPerRem = value;
+        Screen.instance.refreshStyleRootComponents();
+
+        return value;
+    }
+
     public static var autoScale:Bool = true;
     public static var autoScaleDPIThreshold:Int = 160;
     

--- a/haxe/ui/core/Screen.hx
+++ b/haxe/ui/core/Screen.hx
@@ -52,11 +52,13 @@ class Screen extends ScreenBase {
         component.ready();
         rootComponents.push(component);
         FocusManager.instance.pushView(component);
+        component.registerEvent(UIEvent.RESIZE, _onRootComponentResize);    //refresh vh & vw
     }
 
     public override function removeComponent(component:Component) {
         super.removeComponent(component);
         rootComponents.remove(component);
+        component.unregisterEvent(UIEvent.RESIZE, _onRootComponentResize);
     }
 
     public function setComponentIndex(child:Component, index:Int) {
@@ -65,6 +67,25 @@ class Screen extends ScreenBase {
 			rootComponents.remove(child);
 			rootComponents.insert(index, child);
         }
+    }
+
+    public function refreshStyleRootComponents():Void {
+        for(component in rootComponents) {
+            _refreshStyleComponent(component);
+        }
+    }
+
+    @:access(haxe.ui.core.Component)
+    private function _refreshStyleComponent(component:Component):Void {
+        for(child in component.childComponents) {
+            child.applyStyle(child.style);
+            child.invalidateDisplay();
+            _refreshStyleComponent(child);
+        }
+    }
+
+    private function _onRootComponentResize(e:UIEvent):Void {
+        _refreshStyleComponent(e.target);
     }
     
     //***********************************************************************************************************

--- a/haxe/ui/layouts/Layout.hx
+++ b/haxe/ui/layouts/Layout.hx
@@ -196,8 +196,8 @@ class Layout implements ILayout {
             return 0;
         }
         var padding:Float = 0;
-        if (component.style.paddingTop != null) padding += component.style.paddingTop;
-        if (component.style.paddingBottom != null) padding += component.style.paddingBottom;
+        if (component.style.paddingTop != null) padding = component.style.paddingTop + padding;
+        if (component.style.paddingBottom != null) padding = component.style.paddingBottom + padding;
         var icy:Float = component.componentHeight - padding;
         return icy;
     }

--- a/haxe/ui/styles/Defs.hx
+++ b/haxe/ui/styles/Defs.hx
@@ -4,6 +4,9 @@ enum Unit {
     Pix( v : Float );
     Percent( v : Float );
     EM( v : Float );
+    REM( v : Float );
+    VH( v : Float );
+    VW( v : Float );
 }
 
 enum FillStyle {

--- a/haxe/ui/styles/Parser.hx
+++ b/haxe/ui/styles/Parser.hx
@@ -1,5 +1,6 @@
 package haxe.ui.styles;
 
+import haxe.ui.util.Variant;
 import haxe.ui.styles.Defs;
 import haxe.ui.util.MathUtil;
 
@@ -69,52 +70,52 @@ class Parser {
         case "padding":
             switch( v ) {
             case VGroup([a, b]):
-                var a = getVal(a), b = getVal(b);
+                var a = getVariant(a), b = getVariant(b);
                 if( a != null && b != null ) {
                     s.paddingTop = s.paddingBottom = a;
                     s.paddingLeft = s.paddingRight = b;
                     return true;
                 }
             default:
-                var i = getVal(v);
+                var i = getVariant(v);
                 if( i != null ) { s.padding(i); return true; }
             }
         case "padding-top":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.paddingTop = i; return true; }
         case "padding-left":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.paddingLeft = i; return true; }
         case "padding-right":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.paddingRight = i; return true; }
         case "padding-bottom":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.paddingBottom = i; return true; }
         case "margin":
             switch( v ) {
             case VGroup([a, b]):
-                var a = getVal(a), b = getVal(b);
+                var a = getVariant(a), b = getVariant(b);
                 if( a != null && b != null ) {
                     s.marginTop = s.marginBottom = a;
                     s.marginLeft = s.marginRight = b;
                     return true;
                 }
             default:
-                var i = getVal(v);
+                var i = getVariant(v);
                 if( i != null ) { s.margin(i); return true; }
             }
         case "margin-top":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.marginTop = i; return true; }
         case "margin-left":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.marginLeft = i; return true; }
         case "margin-right":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.marginRight = i; return true; }
         case "margin-bottom":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.marginBottom = i; return true; }
         case "width":
             var i = getVal(v);
@@ -132,6 +133,9 @@ class Parser {
                     switch (p) {
                         case Percent(x):
                             s.percentWidth = x * 100;
+                            return true;
+                        case REM(_), VH(_), VW(_):
+                            s.width = p;
                             return true;
                         default:
                     }
@@ -153,6 +157,9 @@ class Parser {
                     switch (p) {
                         case Percent(x):
                             s.percentHeight = x * 100;
+                            return true;
+                        case REM(_), VH(_), VW(_):
+                            s.height = p;
                             return true;
                         default:
                     }
@@ -248,16 +255,16 @@ class Parser {
 
 
         case "background-image-clip-top":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.backgroundImageClipTop = i; return true; }
         case "background-image-clip-left":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.backgroundImageClipLeft = i; return true; }
         case "background-image-clip-bottom":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.backgroundImageClipBottom = i; return true; }
         case "background-image-clip-right":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.backgroundImageClipRight = i; return true; }
         case "background-image-clip":
             if (applyComposite(["background-image-clip-top",
@@ -275,16 +282,16 @@ class Parser {
 
 
         case "background-image-slice-top":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.backgroundImageSliceTop = i; return true; }
         case "background-image-slice-left":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.backgroundImageSliceLeft = i; return true; }
         case "background-image-slice-bottom":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.backgroundImageSliceBottom = i; return true; }
         case "background-image-slice-right":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) { s.backgroundImageSliceRight = i; return true; }
         case "background-image-slice":
             if (applyComposite(["background-image-slice-top",
@@ -336,7 +343,7 @@ class Parser {
                 s.borderRadius = MathUtil.MIN_INT;
                 return true;
             }
-            var i = getVal(v);
+            var i = getVariant(v, true, false);
             if( i != null ) {
                 s.borderRadius = i;
                 return true;
@@ -392,7 +399,7 @@ class Parser {
                 return true;
             }
         case "border-width" | "border-size":
-            var i = getVal(v);
+            var i = getVariant(v, true, false);
             if( i != null ) {
 //              s.borderSize = i;
                 s.borderTopSize = i;
@@ -402,25 +409,25 @@ class Parser {
                 return true;
             }
         case "border-top-width" | "border-top-size":
-            var i = getVal(v);
+            var i = getVariant(v, true, false);
             if( i != null ) {
                 s.borderTopSize = i;
                 return true;
             }
         case "border-left-width" | "border-left-size":
-            var i = getVal(v);
+            var i = getVariant(v, true, false);
             if( i != null ) {
                 s.borderLeftSize = i;
                 return true;
             }
         case "border-bottom-width" | "border-bottom-size":
-            var i = getVal(v);
+            var i = getVariant(v, true, false);
             if( i != null ) {
                 s.borderBottomSize = i;
                 return true;
             }
         case "border-right-width" | "border-right-size":
-            var i = getVal(v);
+            var i = getVariant(v, true, false);
             if( i != null ) {
                 s.borderRightSize = i;
                 return true;
@@ -526,13 +533,13 @@ class Parser {
         case "spacing":
             return applyComposite(["vertical-spacing", "horizontal-spacing"], v, s);
         case "horizontal-spacing":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) {
                 s.horizontalSpacing = i;
                 return true;
             }
         case "vertical-spacing":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) {
                 s.verticalSpacing = i;
                 return true;
@@ -605,13 +612,13 @@ class Parser {
         case "offset":
             return applyComposite(["offset-left", "offset-top"], v, s);
         case "offset-left":
-            var i = getVal(v);
+            var i = getVariant(v);
             if( i != null ) {
                 s.offsetLeft = i;
                 return true;
             }
         case "offset-top":
-            var i = getVal(v);
+            var i = getVariant(v);
             if ( i != null ) {
                 s.offsetTop = i;
                 return true;
@@ -627,7 +634,7 @@ class Parser {
                 return true;
             }
         case "font-size":
-            var i = getVal(v);
+            var i = getVariant(v, true, false);
             if ( i != null ) {
                 s.fontSize = i;
                 return true;
@@ -852,6 +859,9 @@ class Parser {
             switch( u ) {
             case "px": Std.int(f);
             case "pt": Std.int(f * 4 / 3);
+//            case "rem": Std.int(f * pixelsPerRem);
+//            case "vh": Std.int(f / 100 * viewportHeight);
+//            case "vw": Std.int(f / 100 * viewportWidth);
             default: null;
             }
         case VInt(v):
@@ -938,6 +948,9 @@ class Parser {
             case "px": Pix(f);
             case "pt": Pix(f * 4 / 3);
             case "%": Percent(f / 100);
+            case "rem": REM(f);
+            case "vh": VH(f);
+            case "vw": VW(f);
             default: null;
             }
         case VInt(v):
@@ -946,6 +959,27 @@ class Parser {
             Pix(v);
         default:
             null;
+        };
+    }
+
+    function getVariant( v : Value, allowRem:Bool=true, allowViewport:Bool=true) : Null<Variant> {
+        return switch( v ) {
+            case VUnit(f, u):
+                switch( u ) {
+                    case "px": f;
+                    case "pt": f * 4 / 3;
+                    case "%": Percent(f / 100);
+                    case "rem": allowRem ? REM(f) : null;
+                    case "vh": allowViewport ? VH(f) : null;
+                    case "vw": allowViewport ? VW(f) : null;
+                    default: null;
+                }
+            case VInt(v):
+                v;
+            case VFloat(v):
+                v;
+            default:
+                null;
         };
     }
 
@@ -1411,7 +1445,7 @@ class Parser {
                 while( isSpace(c0) )
                     c0 = next();
                 if( c0 != ")".code )
-                    throw "Invalid char " + String.fromCharCode(c0);
+                    throw "Invalid char " + c0;//String.fromCharCode(c0);   //FIXME Error. s : String -> haxe.ui.util.VariantType has no field fromCharCode
                 return s;
             default: throw "assert";
             }

--- a/haxe/ui/styles/Style.hx
+++ b/haxe/ui/styles/Style.hx
@@ -11,26 +11,26 @@ class Style {
 
     @style      public var autoWidth:Null<Bool>;
     @style      public var autoHeight:Null<Bool>;
-    @style      public var verticalSpacing:Null<Variant>;
-    @style      public var horizontalSpacing:Null<Variant>;
+    @style      public var verticalSpacing:Variant;
+    @style      public var horizontalSpacing:Variant;
 
-    @style      public var offsetLeft:Null<Variant>;
-    @style      public var offsetTop:Null<Variant>;
+    @style      public var offsetLeft:Variant;
+    @style      public var offsetTop:Variant;
 
-    @style      public var width:Null<Variant>;
-    @style      public var height:Null<Variant>;
+    @style      public var width:Variant;
+    @style      public var height:Variant;
     @style      public var percentWidth:Null<Float>;
     @style      public var percentHeight:Null<Float>;
 
-    @style      public var paddingTop:Null<Variant>;
-    @style      public var paddingLeft:Null<Variant>;
-    @style      public var paddingRight:Null<Variant>;
-    @style      public var paddingBottom:Null<Variant>;
+    @style      public var paddingTop:Variant;
+    @style      public var paddingLeft:Variant;
+    @style      public var paddingRight:Variant;
+    @style      public var paddingBottom:Variant;
 
-    @style      public var marginTop:Null<Variant>;
-    @style      public var marginLeft:Null<Variant>;
-    @style      public var marginRight:Null<Variant>;
-    @style      public var marginBottom:Null<Variant>;
+    @style      public var marginTop:Variant;
+    @style      public var marginLeft:Variant;
+    @style      public var marginRight:Variant;
+    @style      public var marginBottom:Variant;
 
     @style      public var color:Null<Int>;
 
@@ -42,27 +42,27 @@ class Style {
     @style      public var backgroundImage:Null<String>;
     @style      public var backgroundImageRepeat:Null<String>;
 
-    @style      public var backgroundImageClipTop:Null<Variant>;
-    @style      public var backgroundImageClipLeft:Null<Variant>;
-    @style      public var backgroundImageClipBottom:Null<Variant>;
-    @style      public var backgroundImageClipRight:Null<Variant>;
+    @style      public var backgroundImageClipTop:Variant;
+    @style      public var backgroundImageClipLeft:Variant;
+    @style      public var backgroundImageClipBottom:Variant;
+    @style      public var backgroundImageClipRight:Variant;
 
-    @style      public var backgroundImageSliceTop:Null<Variant>;
-    @style      public var backgroundImageSliceLeft:Null<Variant>;
-    @style      public var backgroundImageSliceBottom:Null<Variant>;
-    @style      public var backgroundImageSliceRight:Null<Variant>;
+    @style      public var backgroundImageSliceTop:Variant;
+    @style      public var backgroundImageSliceLeft:Variant;
+    @style      public var backgroundImageSliceBottom:Variant;
+    @style      public var backgroundImageSliceRight:Variant;
 
     @style      public var borderColor:Null<Int>;
     @style      public var borderTopColor:Null<Int>;
     @style      public var borderLeftColor:Null<Int>;
     @style      public var borderBottomColor:Null<Int>;
     @style      public var borderRightColor:Null<Int>;
-    @style      public var borderSize:Null<Variant>;
-    @style      public var borderTopSize:Null<Variant>;
-    @style      public var borderLeftSize:Null<Variant>;
-    @style      public var borderBottomSize:Null<Variant>;
-    @style      public var borderRightSize:Null<Variant>;
-    @style      public var borderRadius:Null<Variant>;
+    @style      public var borderSize:Variant;
+    @style      public var borderTopSize:Variant;
+    @style      public var borderLeftSize:Variant;
+    @style      public var borderBottomSize:Variant;
+    @style      public var borderRightSize:Variant;
+    @style      public var borderRadius:Variant;
     @style      public var borderOpacity:Null<Float>;
 
     @style      public var filter:Array<Dynamic>;
@@ -79,7 +79,7 @@ class Style {
     @style      public var native:Null<Bool>;
 
     @style      public var fontName:Null<String>;
-    @style      public var fontSize:Null<Variant>;
+    @style      public var fontSize:Variant;
     @style      public var fontBold:Null<Bool>;
     @style      public var fontUnderline:Null<Bool>;
     @style      public var fontItalic:Null<Bool>;
@@ -277,12 +277,12 @@ class Style {
             backgroundColor = null;
             backgroundColorEnd = null;
         }
-//        if (borderSize == MathUtil.MIN_INT) borderSize = null;
-//        if (borderTopSize == MathUtil.MIN_INT) borderTopSize = null;
-//        if (borderLeftSize == MathUtil.MIN_INT) borderLeftSize = null;
-//        if (borderBottomSize == MathUtil.MIN_INT) borderBottomSize = null;
-//        if (borderRightSize == MathUtil.MIN_INT) borderRightSize = null;
-//        if (borderRadius == MathUtil.MIN_INT) borderRadius = null;
+        if (borderSize == MathUtil.MIN_INT) borderSize = null;
+        if (borderTopSize == MathUtil.MIN_INT) borderTopSize = null;
+        if (borderLeftSize == MathUtil.MIN_INT) borderLeftSize = null;
+        if (borderBottomSize == MathUtil.MIN_INT) borderBottomSize = null;
+        if (borderRightSize == MathUtil.MIN_INT) borderRightSize = null;
+        if (borderRadius == MathUtil.MIN_INT) borderRadius = null;
         if (borderColor == MathUtil.MIN_INT) borderColor = null;
         if (borderTopColor == MathUtil.MIN_INT) borderTopColor = null;
         if (borderLeftColor == MathUtil.MIN_INT) borderLeftColor = null;

--- a/haxe/ui/styles/Style.hx
+++ b/haxe/ui/styles/Style.hx
@@ -1,4 +1,5 @@
 package haxe.ui.styles;
+import haxe.ui.util.Variant;
 import haxe.ui.util.MathUtil;
 
 class Style {
@@ -10,26 +11,26 @@ class Style {
 
     @style      public var autoWidth:Null<Bool>;
     @style      public var autoHeight:Null<Bool>;
-    @style      public var verticalSpacing:Null<Float>;
-    @style      public var horizontalSpacing:Null<Float>;
+    @style      public var verticalSpacing:Null<Variant>;
+    @style      public var horizontalSpacing:Null<Variant>;
 
-    @style      public var offsetLeft:Null<Float>;
-    @style      public var offsetTop:Null<Float>;
+    @style      public var offsetLeft:Null<Variant>;
+    @style      public var offsetTop:Null<Variant>;
 
-    @style      public var width:Null<Float>;
-    @style      public var height:Null<Float>;
+    @style      public var width:Null<Variant>;
+    @style      public var height:Null<Variant>;
     @style      public var percentWidth:Null<Float>;
     @style      public var percentHeight:Null<Float>;
 
-    @style      public var paddingTop:Null<Float>;
-    @style      public var paddingLeft:Null<Float>;
-    @style      public var paddingRight:Null<Float>;
-    @style      public var paddingBottom:Null<Float>;
+    @style      public var paddingTop:Null<Variant>;
+    @style      public var paddingLeft:Null<Variant>;
+    @style      public var paddingRight:Null<Variant>;
+    @style      public var paddingBottom:Null<Variant>;
 
-    @style      public var marginTop:Null<Float>;
-    @style      public var marginLeft:Null<Float>;
-    @style      public var marginRight:Null<Float>;
-    @style      public var marginBottom:Null<Float>;
+    @style      public var marginTop:Null<Variant>;
+    @style      public var marginLeft:Null<Variant>;
+    @style      public var marginRight:Null<Variant>;
+    @style      public var marginBottom:Null<Variant>;
 
     @style      public var color:Null<Int>;
 
@@ -41,27 +42,27 @@ class Style {
     @style      public var backgroundImage:Null<String>;
     @style      public var backgroundImageRepeat:Null<String>;
 
-    @style      public var backgroundImageClipTop:Null<Float>;
-    @style      public var backgroundImageClipLeft:Null<Float>;
-    @style      public var backgroundImageClipBottom:Null<Float>;
-    @style      public var backgroundImageClipRight:Null<Float>;
+    @style      public var backgroundImageClipTop:Null<Variant>;
+    @style      public var backgroundImageClipLeft:Null<Variant>;
+    @style      public var backgroundImageClipBottom:Null<Variant>;
+    @style      public var backgroundImageClipRight:Null<Variant>;
 
-    @style      public var backgroundImageSliceTop:Null<Float>;
-    @style      public var backgroundImageSliceLeft:Null<Float>;
-    @style      public var backgroundImageSliceBottom:Null<Float>;
-    @style      public var backgroundImageSliceRight:Null<Float>;
+    @style      public var backgroundImageSliceTop:Null<Variant>;
+    @style      public var backgroundImageSliceLeft:Null<Variant>;
+    @style      public var backgroundImageSliceBottom:Null<Variant>;
+    @style      public var backgroundImageSliceRight:Null<Variant>;
 
     @style      public var borderColor:Null<Int>;
     @style      public var borderTopColor:Null<Int>;
     @style      public var borderLeftColor:Null<Int>;
     @style      public var borderBottomColor:Null<Int>;
     @style      public var borderRightColor:Null<Int>;
-    @style      public var borderSize:Null<Float>;
-    @style      public var borderTopSize:Null<Float>;
-    @style      public var borderLeftSize:Null<Float>;
-    @style      public var borderBottomSize:Null<Float>;
-    @style      public var borderRightSize:Null<Float>;
-    @style      public var borderRadius:Null<Float>;
+    @style      public var borderSize:Null<Variant>;
+    @style      public var borderTopSize:Null<Variant>;
+    @style      public var borderLeftSize:Null<Variant>;
+    @style      public var borderBottomSize:Null<Variant>;
+    @style      public var borderRightSize:Null<Variant>;
+    @style      public var borderRadius:Null<Variant>;
     @style      public var borderOpacity:Null<Float>;
 
     @style      public var filter:Array<Dynamic>;
@@ -78,7 +79,7 @@ class Style {
     @style      public var native:Null<Bool>;
 
     @style      public var fontName:Null<String>;
-    @style      public var fontSize:Null<Float>;
+    @style      public var fontSize:Null<Variant>;
     @style      public var fontBold:Null<Bool>;
     @style      public var fontUnderline:Null<Bool>;
     @style      public var fontItalic:Null<Bool>;
@@ -276,12 +277,12 @@ class Style {
             backgroundColor = null;
             backgroundColorEnd = null;
         }
-        if (borderSize == MathUtil.MIN_INT) borderSize = null;
-        if (borderTopSize == MathUtil.MIN_INT) borderTopSize = null;
-        if (borderLeftSize == MathUtil.MIN_INT) borderLeftSize = null;
-        if (borderBottomSize == MathUtil.MIN_INT) borderBottomSize = null;
-        if (borderRightSize == MathUtil.MIN_INT) borderRightSize = null;
-        if (borderRadius == MathUtil.MIN_INT) borderRadius = null;
+//        if (borderSize == MathUtil.MIN_INT) borderSize = null;
+//        if (borderTopSize == MathUtil.MIN_INT) borderTopSize = null;
+//        if (borderLeftSize == MathUtil.MIN_INT) borderLeftSize = null;
+//        if (borderBottomSize == MathUtil.MIN_INT) borderBottomSize = null;
+//        if (borderRightSize == MathUtil.MIN_INT) borderRightSize = null;
+//        if (borderRadius == MathUtil.MIN_INT) borderRadius = null;
         if (borderColor == MathUtil.MIN_INT) borderColor = null;
         if (borderTopColor == MathUtil.MIN_INT) borderTopColor = null;
         if (borderLeftColor == MathUtil.MIN_INT) borderLeftColor = null;
@@ -291,14 +292,14 @@ class Style {
         if (icon == "none") icon = null;
     }
 
-    public function padding(v:Float) {
+    public function padding(v:Variant) {
         this.paddingTop = v;
         this.paddingLeft = v;
         this.paddingRight = v;
         this.paddingBottom = v;
     }
 
-    public function margin(v:Float) {
+    public function margin(v:Variant) {
         this.marginTop = v;
         this.marginLeft = v;
         this.marginRight = v;

--- a/haxe/ui/util/Variant.hx
+++ b/haxe/ui/util/Variant.hx
@@ -24,12 +24,12 @@ abstract Variant(VariantType) from VariantType {
     @:to public function toString() {
         return switch(this) {
             case String(s): s;
-            case Int(s): return Std.string(s);
-            case Float(s): return Std.string(s);
-            case Unit(s): return Std.string(s);
-            case Bool(s): return Std.string(s);
-            //case Dynamic(s): return Std.string(s);
-            case DataSource(s): return Std.string(s);
+            case Int(s): Std.string(s);
+            case Float(s): Std.string(s);
+            case Unit(s): Std.string(s);
+            case Bool(s): Std.string(s);
+            //case Dynamic(s): Std.string(s);
+            case DataSource(s): Std.string(s);
             default: throw "Variant Type Error";
         }
     }
@@ -46,15 +46,16 @@ abstract Variant(VariantType) from VariantType {
         return Int(s);
     }
 
-    @:to function toInt():Int {
+    @:to function toInt():Null<Int> {
+        if(isNull) return null;
         return switch(this) {
-            case Int(s): return s;
-            case Float(s): return Std.int(s);
+            case Int(s): s;
+            case Float(s): Std.int(s);
             case Unit(s): switch(s) {
-                case Pix(v): return Std.int(v);
-                case REM(v): return Std.int(v * Toolkit.pixelsPerRem);
-                case VH(v): return Std.int(v / 100 * Screen.instance.height);
-                case VW(v): return Std.int(v / 100 * Screen.instance.width);
+                case Pix(v): Std.int(v);
+                case REM(v): Std.int(v * Toolkit.pixelsPerRem);
+                case VH(v): Std.int(v / 100 * Screen.instance.height);
+                case VW(v): Std.int(v / 100 * Screen.instance.width);
                 default: throw "Variant Type Error";
             }
             default: throw "Variant Type Error";
@@ -73,15 +74,16 @@ abstract Variant(VariantType) from VariantType {
         return Float(s);
     }
 
-    @:to function toFloat():Float {
+    @:to function toFloat():Null<Float> {
+        if(isNull) return null;
         return switch(this) {
-            case Float(s): return s;
+            case Float(s): s;
             case Unit(s): switch(s) {
-                case Pix(v): return v;
-                case REM(v): return v * Toolkit.pixelsPerRem;
-                case VH(v): return v / 100 * Screen.instance.height;
-                case VW(v): return v / 100 * Screen.instance.width;
-                default: throw "Variant Type Error";
+                case Pix(v): v;
+                case REM(v): v * Toolkit.pixelsPerRem;
+                case VH(v): v / 100 * Screen.instance.height;
+                case VW(v): v / 100 * Screen.instance.width;
+                default: throw "Variant Typfe Error";
             }
             default: throw "Variant Type Error";
         }
@@ -102,9 +104,9 @@ abstract Variant(VariantType) from VariantType {
 
     @:to function toUnit():StyleUnit {
         return switch(this) {
-            case Int(s): return Pix(s);
-            case Float(s): return Pix(s);
-            case Unit(s): return s;
+            case Int(s): Pix(s);
+            case Float(s): Pix(s);
+            case Unit(s): s;
             default: throw "Variant Type Error";
         }
     }
@@ -124,13 +126,13 @@ abstract Variant(VariantType) from VariantType {
 
     function toNumber():Float {
         return switch(this) {
-            case Int(s): return s;
-            case Float(s): return s;
+            case Int(s): s;
+            case Float(s): s;
             case Unit(s): switch(s) {
-                case Pix(v): return v;
-                case REM(v): return v * Toolkit.pixelsPerRem;
-                case VH(v): return v / 100 * Screen.instance.height;
-                case VW(v): return v / 100 * Screen.instance.width;
+                case Pix(v): v;
+                case REM(v): v * Toolkit.pixelsPerRem;
+                case VH(v): v / 100 * Screen.instance.height;
+                case VW(v): v / 100 * Screen.instance.width;
                 default: throw "Variant Type Error";
             }
             default: throw "Variant Type Error";
@@ -146,7 +148,7 @@ abstract Variant(VariantType) from VariantType {
 
     @:to function toBool() {
         return switch(this) {
-            case Bool(s): return s;
+            case Bool(s): s;
             default: throw "Variant Type Error";
         }
     }
@@ -169,7 +171,7 @@ abstract Variant(VariantType) from VariantType {
 
     @:to function toDataSource() {
         return switch(this) {
-            case DataSource(s): return s;
+            case DataSource(s): s;
             default: throw "Variant Type Error";
         }
     }
@@ -358,17 +360,6 @@ abstract Variant(VariantType) from VariantType {
         throw "Variant operation error";
     }
 
-    @:op(A == B)
-    private function compare(rhs:Variant):Bool {
-        if(isNumber) {
-            return toNumber() == rhs.toNumber();
-        } else if(isString) {
-            return toString() == rhs.toString();
-        }
-
-        throw "Variant operation error";
-    }
-
     @:op(-A)
     private function negate():Variant {
         if(isNumber) {
@@ -393,7 +384,7 @@ abstract Variant(VariantType) from VariantType {
     // ************************************************************************************************************
     public var isNull(get, never):Bool;
     private function get_isNull():Bool {
-        return toString() == null;
+        return this == null || toString() == null;
     }
 
     public static function fromDynamic(r:Dynamic):Variant {


### PR DESCRIPTION
Hi.

I have added new css units:

* rem: based in a global unit. In html it should be the `font-size` global value. Here it is in `Toolkit.pixelsPerRem` (by default 16).

* vh & vw: based in the viewport size. 

Currently it works with OpenFL and my own mobile app.

Also all objects are updated when the viewport size or the `Toolkit.pixelsPerRem` value are changed.

In my own application, i change the `Toolkit.pixelsPerRem` value depending on the DPI value. I work in the desktop version with a fixed DPI (96) or fixed size. At startup then i calculate the new `Toolkit.pixelsPerRem` value when the DPI or the viewport size is different. So you can have PX values without scale and REM values scaled.

Issues
-----

I need help to fix a couple of issues:

1. In `Parser.hx`:
```
throw "Invalid char " + c0;//String.fromCharCode(c0);   //FIXME Error. s : String -> haxe.ui.util.VariantType has no field fromCharCode
```

2. In `Layout.hx`:

```
-        if (component.style.paddingBottom != null) padding += component.style.paddingBottom;	
+        if (component.style.paddingBottom != null) padding = component.style.paddingBottom + padding;
```
The error is `haxe.ui.util.Variant should be Float`. The implicit cast doesn't work.
All code in the form A += B or A -= B doesn't work with Variant. I have tried @:op without successful. It gives the same error with other backends (for example Kha). So i think we need a solution in the Variant code to avoid changes the backends.

Also, this doesn't work neither:

```
if (component.style.paddingBottom != null) padding = padding + component.style.paddingBottom;
```

The implicit cast again. Am i missing something?


Test
----


Here a test example:

![haxeui](https://cloud.githubusercontent.com/assets/1063719/21073459/f780b678-bede-11e6-8bfd-66a9fedf1d0f.JPG)

```
<?xml version="1.0" encoding="utf-8"?>
<vbox id="main" width="100%" height="100%">
    <!-- by default 1rem = 16px -->

    <button id="button1" text="Button1 1rem" 
        style="width: 200px; height:auto; font-size: 1rem;"  />
    <button id="button1" text="Button1 16px" 
        style="width: 200px; font-size: 16px;"  />
    <button id="button2" text="Button2 0.5rem" 
        style="width: 300px; font-size: 0.5rem;" />
    <button id="button2" text="Button2 8px" 
        style="width: 300px; font-size: 8px;" />

    <hbox>
        <button id="button3" text="Button3 2rem" 
            style="width: 20rem; font-size: 2rem;" />
        <button id="button3" text="Button3 32px" 
            style="width: 20rem; font-size: 32px;" />
    </hbox>
    
    <button id="button4" text="Button4 25vw 10vh" 
        style="width: 25vw; height: 10vh;" />
    <button id="button5" text="Button5 50vw 5vh" 
        style="width: 50vw; height: 5vh;" />
    <button id="button6" text="Button6 75vw 15vh" 
        style="width: 75vw; height: 15vh;" />
    <button id="button7" text="Button7 100vw 8vh" 
        style="width: 100vw; height: 8vh;" />

    <label text="Label1 2rem" style="font-size: 2rem;"/>
    <label text="Label1 32px" style="font-size: 32px"/>
    <label text="Label2 0.5rem" style="font-size: 0.5rem;"/>
    <label text="Label2 8px" style="font-size: 8px;"/>
    <label text="Label3 0.625rem" style="font-size: 0.625rem;"/>
    <label text="Label3 10px" style="font-size: 10px;"/>

</vbox>
```

The example works with:
- [x] OpenFL
- [x] HTML5
- [x] nme
- [x] hxWidgets
- [ ] PixiJS (partially, the style doesn't updated when the viewport change)
- [ ] Flambe (issue 2)
- [x] Kha (issue 2)
- [ ] Luxe (not tested yet)
- [x] XWT (rem ok, vh & vw with issues)