### PR TITLE
Fix: CHANGE event doesn't dispatched in some backends (OpenFL, NME...).

### DIFF
--- a/haxe/ui/components/TextField.hx
+++ b/haxe/ui/components/TextField.hx
@@ -45,6 +45,7 @@ class TextField extends InteractiveComponent implements IFocusable implements IC
             componentWidth = 150;
         }
 
+        getTextInput(); //create the text input if it doesn't exist
         registerEvent(MouseEvent.MOUSE_DOWN, _onMouseDown);
         registerEvent(UIEvent.CHANGE, _onTextChanged);
     }


### PR DESCRIPTION
For example, in the backend OpenFL and NME, in the [mapEvent method L237](https://github.com/haxeui/haxeui-openfl/blob/master/haxe/ui/backend/ComponentBase.hx#L237), hasTextInput() is false, so the event can't be mapped.