### PR TITLE
Fix: Wrong state with toggle button if the user clicks up outside of the button.

### DIFF
--- a/haxe/ui/components/Button.hx
+++ b/haxe/ui/components/Button.hx
@@ -208,7 +208,7 @@ class Button extends InteractiveComponent implements IClonable<Button> {
     }
 
     private function _onMouseOut(event:MouseEvent) {
-        if (_toggle == true && hasClass(":down")) {
+        if (_toggle == true && _selected == true) {
             return;
         }
 
@@ -242,6 +242,8 @@ class Button extends InteractiveComponent implements IClonable<Button> {
     private function _onMouseUp(event:MouseEvent) {
         event.cancel();
         _down = false;
+        screen.unregisterEvent(MouseEvent.MOUSE_UP, _onMouseUp);
+
         if (_toggle == true) {
             return;
         }
@@ -257,8 +259,6 @@ class Button extends InteractiveComponent implements IClonable<Button> {
             _repeatTimer = null;
             #end
         }
-
-        screen.unregisterEvent(MouseEvent.MOUSE_UP, _onMouseUp);
     }
 
     private function _onMouseClick(event:MouseEvent) {


### PR DESCRIPTION
With a toggle button, if you press with the mouse inside of the button and release the mouse outside, the button state remains "down". Also the MOUSE_UP event isn't removed.