### PR TITLE
Set the focus once.

### DIFF
--- a/haxe/ui/focus/FocusManager.hx
+++ b/haxe/ui/focus/FocusManager.hx
@@ -66,13 +66,14 @@ class FocusManager {
         if (focusInfo.currentFocus != null && focusInfo.currentFocus != value) {
             focusInfo.currentFocus.focus = false;
             focusInfo.currentFocus = null;
-            Toolkit.screen.focus = null;
         }
         if (value != null) {
             focusInfo.currentFocus = value;
             focusInfo.currentFocus.focus = true;
-            Toolkit.screen.focus = cast value;
         }
+
+        Toolkit.screen.focus = cast value;
+
         return focusInfo.currentFocus;
     }
 


### PR DESCRIPTION
It isn't needed to set the focus twice. It can cause problems in the backends.

For example, with OpenFL and multiple textfields, the focus is previously set in OpenFL code, after that FocusManager set the focus to null, and after that it is set again. I have debugged and some times the last assign doesn't dispatch the OpenFL FOCUS_IN/FOCUS_OUT event, so it is a problem. Sometimes the keyboard in Android is missing when the textfield has the focus, etc... 