### PR TITLE
Fix: Wrong margin with horizontalAlign = right and verticalAlign = bottom

### DIFF
--- a/haxe/ui/layouts/DefaultLayout.hx
+++ b/haxe/ui/layouts/DefaultLayout.hx
@@ -43,7 +43,7 @@ class DefaultLayout extends Layout {
                 case "center":
                     xpos = ((component.componentWidth - child.componentWidth) / 2) + marginLeft(child) - marginRight(child);
                 case "right":
-                    xpos = component.componentWidth - (child.componentWidth + paddingRight + marginLeft(child));
+                    xpos = component.componentWidth - (child.componentWidth + paddingRight + marginRight(child));
                 default:    //left
                     xpos = paddingLeft + marginLeft(child);
             }
@@ -52,7 +52,7 @@ class DefaultLayout extends Layout {
                 case "center":
                     ypos = ((component.componentHeight - child.componentHeight) / 2) + marginTop(child) - marginBottom(child);
                 case "bottom":
-                    ypos = component.componentHeight - (child.componentHeight + paddingBottom + marginTop(child));
+                    ypos = component.componentHeight - (child.componentHeight + paddingBottom + marginBottom(child));
                 default:    //top
                     ypos = paddingTop + marginTop(child);
             }


### PR DESCRIPTION
With the next code:

```
var main:Box = new Box();
main.backgroundColor = 0xFF0000;
main.width = 200;
main.height = 200;

var button:Button = new Button();
button.customStyle.verticalAlign = "bottom";
button.customStyle.marginBottom = 40;
button.text = "Button";
main.addComponent(button);
```

![image](https://cloud.githubusercontent.com/assets/1063719/23038161/53d9580a-f489-11e6-9082-d19e5c224788.png)

The PR fix that:

![image](https://cloud.githubusercontent.com/assets/1063719/23038244/9940fccc-f489-11e6-88b5-bcdeaaf39cec.png)


And the example from https://github.com/haxeui/haxeui-core/pull/67 is working too.
