### PR TITLE
Fix: SyncUI isn't called in some situations.

### DIFF
--- a/haxe/ui/containers/ListView.hx
+++ b/haxe/ui/containers/ListView.hx
@@ -172,7 +172,7 @@ class ListView extends ScrollView implements IDataComponent {
     }
 
     private function syncUI() {
-        if ((_itemRenderer == null && _itemRendererFunction == null) || _dataSource == null) {
+        if (_dataSource == null) {
             return;
         }
 


### PR DESCRIPTION
It isn't needed. ItemToRenderer function creates the BasicItemRenderer instance if _itemRenderer or _itemRendererFunction are null.