### PR TITLE
Fix: Wrong behaviours with custom renderers.

### DIFF
--- a/haxe/ui/containers/ListView.hx
+++ b/haxe/ui/containers/ListView.hx
@@ -28,13 +28,6 @@ class ListView extends ScrollView implements IDataComponent {
         _contents.percentWidth = 100;
         _contents.addClass("listview-contents");
     }
-
-    private override function onReady() {
-        super.onReady();
-        if (_itemRenderer == null) {
-            addComponent(new BasicItemRenderer());
-        }
-    }
     
     public override function addComponent(child:Component):Component {
         var r = null;
@@ -90,10 +83,6 @@ class ListView extends ScrollView implements IDataComponent {
     }
 
     public function addItem(data:Dynamic):ItemRenderer {
-        if (_itemRenderer == null && _itemRendererFunction == null) {
-            return null;
-        }
-
         var r = itemToRenderer(data);
         r.percentWidth = 100;
         var n = contents.childComponents.length;


### PR DESCRIPTION
It is related to #123.

The BasicItemRenderer creation should be when it is really used (itemToRenderer should do that).

Yesterday I did sync my dev branch with master and I had this weird behaviour with the Grid:

![listview](https://cloud.githubusercontent.com/assets/1063719/24718785/9686d29e-1a37-11e7-8240-a4bb6755c52c.JPG)

The PR fixes that.