### PR TITLE
Clone 0th Slice9 rect

### DIFF
--- a/haxe/ui/util/Slice9.hx
+++ b/haxe/ui/util/Slice9.hx
@@ -40,7 +40,7 @@ class Slice9 {
     public static function buildDstRects(w:Float, h:Float, srcRects:Array<Rectangle>):Array<Rectangle> {
         var dstRects:Array<Rectangle> = [];
 
-        dstRects.push(srcRects[0]);
+        dstRects.push(new Rectangle(0, 0, srcRects[0].width, srcRects[0].height));
         dstRects.push(new Rectangle(srcRects[0].width, 0, w - srcRects[0].width - srcRects[2].width, srcRects[1].height));
         dstRects.push(new Rectangle(w - srcRects[2].width, 0, srcRects[2].width, srcRects[2].height));
 


### PR DESCRIPTION
I need to manipulate the src rects but not the dst ones from `Slice9`, and that's not (easily) possible if `dst[0]` and `src[0]` are the exact same object.