### PR TITLE
Find components in inactive TabView tabs.

### DIFF
--- a/haxe/ui/containers/TabView.hx
+++ b/haxe/ui/containers/TabView.hx
@@ -88,6 +88,19 @@ class TabView extends Component {
         return v;
     }
 
+    public override function findComponent<T>(criteria:String = null, type:Class<T> = null, recursive:Null<Bool> = null, searchType:String = "id"):Null<T> {
+        var match = super.findComponent(criteria, type, recursive, searchType);
+        if (match == null) {
+            for (view in _views) {
+                match = view.findComponent(criteria, type, recursive, searchType);
+                if (match != null) {
+                    break;
+                }
+            }
+        }
+        return cast match;
+    }
+
     //***********************************************************************************************************
     // Public API
     //***********************************************************************************************************


### PR DESCRIPTION
Currently findComponent on a TabView will only search the active tab. This PR searches all tabs if a component isn't found in the active tab.