### PR TITLE
Adding support for Tree in Listview

### DIFF
--- a/haxe/ui/core/TreeItemRenderer.hx
+++ b/haxe/ui/core/TreeItemRenderer.hx
@@ -1,0 +1,41 @@
+package haxe.ui.core;
+
+import haxe.ui.components.Label;
+import haxe.ui.containers.ListView;
+import haxe.ui.containers.VBox;
+import haxe.ui.data.DataSource;
+
+class TreeItemRenderer extends ItemRenderer {
+    public var button:Label = new Label();
+    public var list:ListView = new ListView();
+    public function new() {
+        super();
+        addClass("itemrenderer"); // TODO: shouldnt have to do this
+        this.percentWidth = 100;
+
+        var vbox:VBox = new VBox();
+        vbox.percentWidth = 100;
+        button.percentWidth = 100;
+        button.onClick = function (e:UIEvent) {
+            if (list.hidden) { list.show(); }
+            else { list.hide(); }
+        }
+
+        list.id = "value";
+        list.percentWidth = 90;
+        vbox.addComponent(button);
+        vbox.addComponent(list);
+
+        addComponent(vbox);
+    }
+
+    private override function get_data():Dynamic {
+        return _data;
+    }
+    private override function set_data(value:Dynamic):Dynamic {
+        _data = value;
+        button.text = value.label;
+        list.dataSource = value.data;
+        return value;
+    }
+}


### PR DESCRIPTION
Add the possibility to put trees, which can be folded, in a ListView.

Tested on haxeui-html5 and haxeui-hxwidget (using Button instead of Label in the renderer see #137).

I'll try to add a screenshot later.

## Example

```haxe
class Main {

	public static function main() {

		Toolkit.theme = "native";
		var app = new HaxeUIApp();
		app.ready(function() {

			var main:Component = ComponentMacros.buildComponent("assets/ui/main.xml");
			var listview:ListView = main.findComponent("list");

			var subTransformer:IItemTransformer<String> = cast new NativeTypeTransformer();
	
			var dataSource = new ArrayDataSource<{label:String, data:DataSource<String>}>();
			var subDataSource = new ArrayDataSource<String>(subTransformer);
			subDataSource.add("1");
			subDataSource.add("2");
			dataSource.add({label:"a", data:subDataSource});

			subDataSource = new ArrayDataSource<String>(subTransformer);
			subDataSource.add("3");
			dataSource.add({label:"b", data:subDataSource});

			listview.itemRendererFunction = function(data:Dynamic) {
				return new ClassFactory<ItemRenderer>(
					cast Type.resolveClass("haxe.ui.core.TreeItemRenderer"),
					["data" => data]
				);
			}
			listview.dataSource = dataSource;
			app.addComponent(main);
			app.start();

		});
	}
}
```

```xml
<?xml version="1.0" encoding="utf-8"?>
<hbox id="main" width="100%" height="100%">
<style source="../css/main.css" />
    <listview id="list" width="30%" height="100%"/>

    <textarea id="chapter" width="70%" height="100%"/>
</hbox>
```