### PR TITLE
Find non-children

### DIFF
--- a/haxe/ui/containers/TabView.hx
+++ b/haxe/ui/containers/TabView.hx
@@ -92,7 +92,11 @@ class TabView extends Component {
         var match = super.findComponent(criteria, type, recursive, searchType);
         if (match == null) {
             for (view in _views) {
-                match = view.findComponent(criteria, type, recursive, searchType);
+                if (view.matchesSearch(criteria, type, searchType)) {
+                    return cast view;
+			 } else {
+                    match = view.findComponent(criteria, type, recursive, searchType);
+                }
                 if (match != null) {
                     break;
                 }

--- a/haxe/ui/containers/TabView.hx
+++ b/haxe/ui/containers/TabView.hx
@@ -94,7 +94,7 @@ class TabView extends Component {
             for (view in _views) {
                 if (view.matchesSearch(criteria, type, searchType)) {
                     return cast view;
-			 } else {
+                } else {
                     match = view.findComponent(criteria, type, recursive, searchType);
                 }
                 if (match != null) {

--- a/haxe/ui/core/Component.hx
+++ b/haxe/ui/core/Component.hx
@@ -584,6 +584,29 @@ class Component extends ComponentBase implements IComponentBase implements IClon
     }
 
     /**
+     Checks if this component meets the search criteria
+
+     - `criteria` - The criteria by which to search, the interpretation of this is defined using `searchType` (the default search type is _id_)
+
+     - `type` - The component class you wish to cast the result to (defaults to _null_)
+
+     - `searchType` - Allows you specify how to consider a parent a match (defaults to _id_), can be either:
+
+            - `id` - The first component that has the id specified in `criteria` will be considered a match
+
+            - `css` - The first component that contains a style name specified by `criteria` will be considered a match
+    **/
+    @:dox(group = "Display tree related properties and methods")
+    public function matchesSearch<T>(criteria:String = null, type:Class<T> = null, searchType:String = "id"):Bool {
+        if (criteria != null) {
+            return searchType == "id" && id == criteria || searchType == "css" && hasClass(criteria) == true;
+        } else if (type != null) {
+            return Std.is(this, type) == true;
+        }
+	   return false;
+    }
+
+    /**
      Finds a specific child in this components display tree (recusively if desired) and can optionally cast the result
 
      - `criteria` - The criteria by which to search, the interpretation of this is defined using `searchType` (the default search type is _id_)
@@ -606,19 +629,9 @@ class Component extends ComponentBase implements IComponentBase implements IClon
 
         var match:Component = null;
         for (child in childComponents) {
-            if (criteria != null) {
-                if (searchType == "id" && child.id == criteria) {
-                    match = cast child;
-                    break;
-                } else if (searchType == "css" && child.hasClass(criteria) == true) {
-                    match = cast child;
-                    break;
-                }
-            } else if (type != null) {
-                if (Std.is(child, type) == true) {
-                    match = cast child;
-                    break;
-                }
+            if (child.matchesSearch(criteria, type, searchType)) {
+                 match = child;
+                 break;
             }
         }
         if (match == null && recursive == true) {
@@ -652,19 +665,11 @@ class Component extends ComponentBase implements IComponentBase implements IClon
         var match:Component = null;
         var p = this.parentComponent;
         while (p != null) {
-            if (criteria != null) {
-                if (searchType == "id" && p.id == criteria) {
-                    match = cast p;
-                    break;
-                } else if (searchType == "css" && p.hasClass(criteria) == true) {
-                    match = cast p;
-                    break;
-                }
-            } else if (type != null) {
-                if (Std.is(p, type) == true) {
-                    match = cast p;
-                    break;
-                }
+            if (p.matchesSearch(criteria, type, searchType)) {
+                 match = p;
+                 break;
+            } else {
+                 p = p.parentComponent;
             }
         }
         return cast match;
@@ -803,12 +808,12 @@ class Component extends ComponentBase implements IComponentBase implements IClon
                 invalidateStyle();
             }
         }
-		
-		if (recursive == true) {
-			for (child in childComponents) {
-				child.addClass(name, invalidate, recursive);
-			}
-		}
+          
+          if (recursive == true) {
+               for (child in childComponents) {
+                    child.addClass(name, invalidate, recursive);
+               }
+          }
     }
 
     /**
@@ -823,11 +828,11 @@ class Component extends ComponentBase implements IComponentBase implements IClon
             }
         }
 
-		if (recursive == true) {
-			for (child in childComponents) {
-				child.removeClass(name, invalidate, recursive);
-			}
-		}
+          if (recursive == true) {
+               for (child in childComponents) {
+                    child.removeClass(name, invalidate, recursive);
+               }
+          }
     }
 
     /**


### PR DESCRIPTION
Added `matchesSearch()` which returns if  `this` component matches the search criteria. Previously, you could only check children of components and not the components themselves.

Added this to `TabView` so inactive views also get checked, not just their children, since inactive views aren't children of anything, to my knowledge.

Also seemed like `findAncestor()` did not climb up the ancestry tree and would cause an infinite loop if used?