### PR TITLE
Fix applyStyle when the component is created and Haxe code is used to set some properties after the creation.

### DIFF
--- a/haxe/ui/components/Button.hx
+++ b/haxe/ui/components/Button.hx
@@ -279,6 +279,7 @@ class ButtonDefaultTextBehaviour extends Behaviour {
             label.id = "button-label";
             label.scriptAccess = false;
             button.addComponent(label);
+            button.applyStyle(button._style);
         }
         label.text = value;
     }
@@ -310,6 +311,7 @@ class ButtonDefaultIconBehaviour extends Behaviour {
             icon.id = "button-icon";
             icon.scriptAccess = false;
             button.addComponent(icon);
+            button.applyStyle(button._style);
         }
 
         icon.resource = value.toString();

--- a/haxe/ui/components/CheckBox.hx
+++ b/haxe/ui/components/CheckBox.hx
@@ -167,6 +167,7 @@ class CheckBoxDefaultTextBehaviour extends Behaviour {
             label.registerEvent(MouseEvent.MOUSE_OUT, checkbox._onMouseOut);
 
             checkbox.addComponent(label);
+            checkbox.applyStyle(checkbox._style);
         }
         label.text = value;
     }

--- a/haxe/ui/components/OptionBox.hx
+++ b/haxe/ui/components/OptionBox.hx
@@ -276,6 +276,7 @@ class OptionBoxDefaultTextBehaviour extends Behaviour {
             optionbox._label.registerEvent(MouseEvent.MOUSE_OUT, optionbox._onMouseOut);
 
             optionbox.addComponent(optionbox._label);
+            optionbox.applyStyle(optionbox._style);
         }
         optionbox._label.text = value;
     }


### PR DESCRIPTION
Some components have a problem to update the styles at startup when you use Haxe instead of xml to set the properties.

See the next example:


```
var app = new HaxeUIApp();
app.ready(function() {
    var main:VBox = new VBox();
    main.styleString = "width: 100%; height: 100%";

    var button:Button = new Button();
    button.styleString = "color: #EA6037;";
    //button.text = "Button";   //it works
    main.addComponent(button);

    app.addComponent(main);
    app.start();

    button.text = "Button";     //it doesn't work
});
```
 
When the button is created and if I set the text after that, the style isn't updated.


I think that it won't be a problem with the validation branch, but it doesn't work right now in master. It isn't a perfect solution, but it works and it is efficient. 

Another solution is to use invalidateStyle. But you can't invalidate the style because invalidateStyle is skipped when the style hasn't changed. So we need a "force" parameter in invalidateStyle, but it is less efficient, and it will be useless in the validation branch.
