### PR TITLE
Fix for flixel text

### DIFF
--- a/haxe/ui/components/Label.hx
+++ b/haxe/ui/components/Label.hx
@@ -73,14 +73,18 @@ class Label extends Component {
 class LabelLayout extends DefaultLayout {
     private override function resizeChildren() {
         if (component.autoWidth == false) {
-            #if !pixijs
+			#if flixel
+			component.getTextDisplay().textField.multiline = true;
+			component.getTextDisplay().textField.wordWrap = true;
+			component.getTextDisplay().fieldWidth = component.componentWidth - paddingLeft - paddingRight;
+            #elseif !pixijs
             component.getTextDisplay().width = component.componentWidth - paddingLeft - paddingRight;
-            #end
-
-            #if (openfl && !flixel) // TODO: make not specific
+			#if openfl // TODO: make not specific
             component.getTextDisplay().multiline = true;
             component.getTextDisplay().wordWrap = true;
             #end
+            #end
+            
         }
     }
 

--- a/haxe/ui/components/Label.hx
+++ b/haxe/ui/components/Label.hx
@@ -73,13 +73,13 @@ class Label extends Component {
 class LabelLayout extends DefaultLayout {
     private override function resizeChildren() {
         if (component.autoWidth == false) {
-			#if flixel
-			component.getTextDisplay().textField.multiline = true;
-			component.getTextDisplay().textField.wordWrap = true;
-			component.getTextDisplay().fieldWidth = component.componentWidth - paddingLeft - paddingRight;
+            #if flixel
+            component.getTextDisplay().textField.multiline = true;
+            component.getTextDisplay().textField.wordWrap = true;
+            component.getTextDisplay().fieldWidth = component.componentWidth - paddingLeft - paddingRight;
             #elseif !pixijs
             component.getTextDisplay().width = component.componentWidth - paddingLeft - paddingRight;
-			#if openfl // TODO: make not specific
+            #if openfl // TODO: make not specific
             component.getTextDisplay().multiline = true;
             component.getTextDisplay().wordWrap = true;
             #end


### PR DESCRIPTION
FlxText uses `fieldWidth`, not `width`, and still needs the `wordWrap` and `multiline` bits.