### PR TITLE
Reorder scroll mouse event

### DIFF
--- a/haxe/ui/components/Scroll.hx
+++ b/haxe/ui/components/Scroll.hx
@@ -42,6 +42,8 @@ class Scroll extends InteractiveComponent {
             componentHeight = 100;
         }
 
+        registerEvent(MouseEvent.MOUSE_DOWN, _onMouseDown);
+
         if (_deincButton == null) {
             _deincButton = new Button();
             _deincButton.scriptAccess = false;
@@ -80,8 +82,6 @@ class Scroll extends InteractiveComponent {
             _thumb.registerEvent(MouseEvent.MOUSE_DOWN, _onThumbMouseDown);
             addComponent(_thumb);
         }
-
-        registerEvent(MouseEvent.MOUSE_DOWN, _onMouseDown);
     }
 
     //***********************************************************************************************************


### PR DESCRIPTION
Helps backends where event order matters. OpenFL automatically handles the parent-child event bubbling, Kha doesn't khare™ since it manually handles the order, but flixel needs children's events to be added after the parent's. I'm not sure if this is the only case.

It's not the best with respect to users adding their own events, but there's not a lot I can do without a lot of `@:access`ing things I shouldn't be touching.