### PR TITLE
make findComponent and findAncestor more type safe

### DIFF
--- a/haxe/ui/containers/TabView.hx
+++ b/haxe/ui/containers/TabView.hx
@@ -108,8 +108,8 @@ class TabView extends Component {
         return v;
     }
 
-    public override function findComponent<T>(criteria:String = null, type:Class<T> = null, recursive:Null<Bool> = null, searchType:String = "id"):Null<T> {
-        var match = super.findComponent(criteria, type, recursive, searchType);
+    public override function findComponent<T: Component>(criteria:String = null, type:Class<T> = null, recursive:Null<Bool> = null, searchType:String = "id"):Null<T> {
+        var match: Component = super.findComponent(criteria, type, recursive, searchType);
         if (match == null && _views != null) {
             for (view in _views) {
                 match = view.findComponent(criteria, type, recursive, searchType);

--- a/haxe/ui/core/Component.hx
+++ b/haxe/ui/core/Component.hx
@@ -522,8 +522,8 @@ class Component extends ComponentBase implements IComponentBase implements IVali
         if (deferredBindings != null) {
             var itemsToRemove:Array<DeferredBindingInfo> = [];
             for (binding in deferredBindings) {
-                var source = findComponent(binding.sourceId, null, true);
-                var target = findComponent(binding.targetId, null, true);
+                var source: Component = findComponent(binding.sourceId, null, true);
+                var target: Component = findComponent(binding.targetId, null, true);
                 if (source != null && target != null) {
                     source.addBinding(target, binding.transform, binding.targetProperty,  binding.sourceProperty);
                     itemsToRemove.push(binding);
@@ -573,8 +573,8 @@ class Component extends ComponentBase implements IComponentBase implements IVali
         if (deferredBindings != null) {
             var itemsToRemove:Array<DeferredBindingInfo> = [];
             for (binding in deferredBindings) {
-                var source = findComponent(binding.sourceId, null, true);
-                var target = findComponent(binding.targetId, null, true);
+                var source: Component = findComponent(binding.sourceId, null, true);
+                var target: Component = findComponent(binding.targetId, null, true);
                 if (source != null && target != null) {
                     source.addBinding(target, binding.transform, binding.targetProperty,  binding.sourceProperty);
                     itemsToRemove.push(binding);
@@ -706,7 +706,7 @@ class Component extends ComponentBase implements IComponentBase implements IVali
             - `css` - The first component that contains a style name specified by `criteria` will be considered a match
     **/
     @:dox(group = "Display tree related properties and methods")
-    public function findComponent<T>(criteria:String = null, type:Class<T> = null, recursive:Null<Bool> = null, searchType:String = "id"):Null<T> {
+    public function findComponent<T: Component>(criteria:String = null, type:Class<T> = null, recursive:Null<Bool> = null, searchType:String = "id"):Null<T> {
         if (recursive == null && criteria != null && searchType == "id") {
             recursive = true;
         }
@@ -755,7 +755,7 @@ class Component extends ComponentBase implements IComponentBase implements IVali
             - `css` - The first component that contains a style name specified by `criteria` will be considered a match
     **/
     @:dox(group = "Display tree related properties and methods")
-    public function findAncestor<T>(criteria:String = null, type:Class<T> = null, searchType:String = "id"):Null<T> {
+    public function findAncestor<T: Component>(criteria:String = null, type:Class<T> = null, searchType:String = "id"):Null<T> {
         var match:Component = null;
         var p = this.parentComponent;
         while (p != null) {


### PR DESCRIPTION
when the existing findComponent is used without explicit typing a Dynamic is returned

```haxe
var some = main.findComponent("foo");
trace(some.text); // generates some.text instead of some.get_text();
```
with my change the user is forced to explicit type the call:

```haxe
var some = main.findComponent("foo"); // does not compile
var some:Component = main.findComponent("foo"); // does compile
trace(some.text); // generates the expected some.get_text();
```