### PR TITLE
haxe 4 don't parse `function () { } (e)` as a call anymore

### DIFF
--- a/haxe/ui/macros/BackendMacros.hx
+++ b/haxe/ui/macros/BackendMacros.hx
@@ -12,14 +12,14 @@ class BackendMacros {
     macro public static function processBackend():Expr {
         loadBackendProperties();
 
-        var code:String = "function() {\n";
+        var code:String = "(function() {\n";
         for (name in properties.names()) {
             code += 'Toolkit.backendProperties.setProp("${name}", "${properties.getProp(name)}");\n';
         }
         if (Context.getDefines().exists("theme")) {
             code += 'Toolkit.theme = "${Context.getDefines().get("theme")}";\n';
         }
-        code += "}()\n";
+        code += "})()\n";
         return Context.parseInlineString(code, Context.currentPos());
     }
 

--- a/haxe/ui/macros/ModuleMacros.hx
+++ b/haxe/ui/macros/ModuleMacros.hx
@@ -20,7 +20,7 @@ class ModuleMacros {
             return macro null;
         }
 
-        var code:String = "function() {\n";
+        var code:String = "(function() {\n";
 
         loadModules();
         for (m in _modules) {
@@ -140,7 +140,7 @@ class ModuleMacros {
             code += 'haxe.ui.core.ComponentClassMap.register("${alias}", "${className}");\n';
         }
 
-        code += "}()\n";
+        code += "})()\n";
         //trace(code);
 
         _modulesProcessed = true;

--- a/haxe/ui/macros/NativeMacros.hx
+++ b/haxe/ui/macros/NativeMacros.hx
@@ -16,14 +16,14 @@ class NativeMacros {
             return macro null;
         }
 
-        var code:String = "function() {\n";
+        var code:String = "(function() {\n";
 
         var nativeConfigs:Array<GenericConfig> = loadNativeConfig();
         for (config in nativeConfigs) {
             code += MacroHelpers.buildGenericConfigCode(config, "nativeConfig");
         }
 
-        code += "}()\n";
+        code += "})()\n";
 
         _nativeProcessed = true;
         return Context.parseInlineString(code, Context.currentPos());


### PR DESCRIPTION
changed the calls in the macros to:
```haxe
( function(){} ) ()
```
which is the valid syntax now and should work for lower versions too.