### PR TITLE
DRY a bit

### DIFF
--- a/haxe/ui/components/TabBar2.hx
+++ b/haxe/ui/components/TabBar2.hx
@@ -240,61 +240,52 @@ private class Builder extends CompositeBuilder {
         }
     }
     
-    private function addTab(child:Component):Component {
+    private function addTab(child:Component, add:Component->Void):Void {
         child.addClass("tabbar-button");
-        var v = _container.addComponent(child); 
+        add(child); 
         _tabbar.registerInternalEvents(Events, true);
         if (_tabbar.selectedIndex < 0) {
             _tabbar.selectedIndex = 0;
         }
-        return v;
-    }
-    
-    // TODO: DRY with addTab
-    private function addTabAt(child:Component, index:Int):Component {
-        child.addClass("tabbar-button");
-        var v = _container.addComponentAt(child, index); 
-        _tabbar.registerInternalEvents(Events, true);
-        if (_tabbar.selectedIndex < 0) {
-            _tabbar.selectedIndex = 0;
-        }
-        return v;
     }
     
     public override function get_numComponents():Int {
         return _container.numComponents;
     }
     
+    inline function isInternal(c:Component) {
+        return c == _container || c == _scrollLeft || c == _scrollRight;
+    }
+    
     public override function addComponent(child:Component):Component {
-        if (child != _container && child != _scrollLeft && child != _scrollRight) {
-            return addTab(child);
+        if (!isInternal(child)) {
+            addTab(child, _container.addComponent);
+            return child;
         }
         return null;
     }
     
     public override function addComponentAt(child:Component, index:Int):Component {
-        if (child != _container && child != _scrollLeft && child != _scrollRight) {
-            return addTabAt(child, index);
+        if (!isInternal(child)) {
+            addTab(child, _container.addComponentAt.bind(_, index));
+            return child;
         }
         return null;
     }
     
     public override function removeComponent(child:Component, dispose:Bool = true, invalidate:Bool = true):Component {
-        if (child != _container && child != _scrollLeft && child != _scrollRight) {
+        if (!isInternal(child)) {
             return _container.removeComponent(child, dispose, invalidate);
         }
         return null;
     }
     
     public override function getComponentIndex(child:Component):Int {
-        if (child != _container && child != _scrollLeft && child != _scrollRight) {
-            return _container.getComponentIndex(child);
-        }
-        return -1;
+        return _container.getComponentIndex(child);
     }
     
     public override function setComponentIndex(child:Component, index:Int):Component {
-        if (child != _container && child != _scrollLeft && child != _scrollRight) {
+        if (!isInternal(child)) {
             return _container.setComponentIndex(child, index);
         }
         return null;

--- a/haxe/ui/containers/ScrollView2.hx
+++ b/haxe/ui/containers/ScrollView2.hx
@@ -623,22 +623,26 @@ class ScrollViewBuilder extends CompositeBuilder {
         return _contents.numComponents;
     }
     
+    inline function isInternal(c:Component) {
+        return Std.is(c, HorizontalScroll2) || Std.is(c, VerticalScroll2) || c.hasClass("scrollview-contents");
+    }
+    
     public override function addComponent(child:Component):Component {
-        if (Std.is(child, HorizontalScroll2) == false && Std.is(child, VerticalScroll2) == false && child.hasClass("scrollview-contents") == false) {
+        if (!isInternal(child)) {
             return _contents.addComponent(child);
         }
         return null;
     }
     
     public override function addComponentAt(child:Component, index:Int):Component {
-        if (Std.is(child, HorizontalScroll2) == false && Std.is(child, VerticalScroll2) == false && child.hasClass("scrollview-contents") == false) {
+        if (!isInternal(child)) {
             return _contents.addComponentAt(child, index);
         }
         return null;
     }
     
     public override function removeComponent(child:Component, dispose:Bool = true, invalidate:Bool = true):Component {
-        if (Std.is(child, HorizontalScroll2) == false && Std.is(child, VerticalScroll2) == false && child.hasClass("scrollview-contents") == false) {
+        if (!isInternal(child)) {
             return _contents.removeComponent(child, dispose, invalidate);
         }
         return null;
@@ -649,7 +653,7 @@ class ScrollViewBuilder extends CompositeBuilder {
     }
     
     public override function setComponentIndex(child:Component, index:Int):Component {
-        if (Std.is(child, HorizontalScroll2) == false && Std.is(child, VerticalScroll2) == false && child.hasClass("scrollview-contents") == false) {
+        if (!isInternal(child)) {
             return _contents.setComponentIndex(child, index);
         }
         return null;

--- a/haxe/ui/containers/TabView2.hx
+++ b/haxe/ui/containers/TabView2.hx
@@ -235,46 +235,45 @@ private class Builder extends CompositeBuilder {
         }
     }
     
+    private function addTab(child:Component, add:Component->Void):Void {
+        var text:String = child.text;
+        var icon:String = null;
+        if (Std.is(child, Box)) {
+            icon = cast(child, Box).icon;
+        }
+        _views.push(child);
+        var button:Button = new Button();
+        button.text = text;
+        button.icon = icon;
+        add(button);
+    }
+    
     public override function get_numComponents():Int {
         return _views.length;
     }
     
+    inline function isInternal(c:Component) {
+        return c == _content || c == _tabs;
+    }
+    
     public override function addComponent(child:Component):Component {
-        if (child != _content && child != _tabs) {
-            var text:String = child.text;
-            var icon:String = null;
-            if (Std.is(child, Box)) {
-                icon = cast(child, Box).icon;
-            }
-            _views.push(child);
-            var button:Button = new Button();
-            button.text = text;
-            button.icon = icon;
-            _tabs.addComponent(button);
+        if (!isInternal(child)) {
+            addTab(child, _tabs.addComponent);
             return child;
         }
         return null;
     }
     
     public override function addComponentAt(child:Component, index:Int):Component {
-        if (child != _content && child != _tabs) {
-            var text:String = child.text;
-            var icon:String = null;
-            if (Std.is(child, Box)) {
-                icon = cast(child, Box).icon;
-            }
-            _views.insert(index, child);
-            var button:Button = new Button();
-            button.text = text;
-            button.icon = icon;
-            _tabs.addComponentAt(button, index);
+        if (!isInternal(child)) {
+            addTab(child, _tabs.addComponentAt.bind(_, index));
             return child;
         }
         return null;
     }
     
     public override function removeComponent(child:Component, dispose:Bool = true, invalidate:Bool = true):Component {
-        if (child != _content && child != _tabs) {
+        if (!isInternal(child)) {
             switch _views.indexOf(child) {
                 case -1:
                 case i:
@@ -291,7 +290,7 @@ private class Builder extends CompositeBuilder {
     }
     
     public override function setComponentIndex(child:Component, index:Int):Component {
-        if (child != _content && child != _tabs) {
+        if (!isInternal(child)) {
             switch _views.indexOf(child) {
                 case -1:
                 case i:


### PR DESCRIPTION
Here I only updated some classes that I have been working on in the previous PR.

However, actually repetitive/redundant code are quite widespread in the repo, not sure if it worth a fix though, especially when there are no unit tests exist.

Here are some examples:

1. `var` and `function` are by default private unless explicitly declared `public`, so `private var x` can be simply written as `var x`
1. `public override function`: the accessor (public/private) can be omitted if it is unchanged vs the super one
1. `== true` is redundant and `== false` can be replaced by prefix `!` unless the bool value is nullable.
1. Repetitive safe casts `cast(value, TheType)`. Note that safe casts have runtime performance impact. If the type are known at compile time, unsafe casts will be more suitable `var v:TheType = cast value`