### PR TITLE
Fixed scroll jump on inc/deinc buttons. More reliable button repeater…

### DIFF
--- a/haxe/ui/components/Button.hx
+++ b/haxe/ui/components/Button.hx
@@ -389,8 +389,12 @@ class ButtonEvents extends haxe.ui.core.Events {
         if (_repeater == true) {
             _repeatTimer = new Timer(_button.repeatInterval, onRepeatTimer);
         } else if (_button.repeater == true) {
+			if (_repeatTimer != null) {
+				_repeatTimer.stop();
+				_repeatTimer = null;
+			}
 			Timer.delay(function():Void {
-				if (_repeater == true) onMouseDown(event);
+				if (_repeater == true && _repeatTimer == null) onMouseDown(event);
 			}, _button.repeatInterval * 2);
 		}
 		_repeater = _button.repeater;

--- a/haxe/ui/components/Scroll2.hx
+++ b/haxe/ui/components/Scroll2.hx
@@ -108,7 +108,10 @@ private class Events extends haxe.ui.core.Events  {
     }
     
     private function onMouseDown(event:MouseEvent) {
-        _scroll.applyPageFromCoord(new Point(event.screenX, event.screenY));
+		// if mouse isn't pressing _deincButton or _incButton...
+		if (_deincButton.hitTest(event.screenX, event.screenY) == false && _incButton.hitTest(event.screenX, event.screenY) == false) {
+			_scroll.applyPageFromCoord(new Point(event.screenX, event.screenY));
+		}
     }
     
     private function onDeinc(event:MouseEvent) {


### PR DESCRIPTION
Scrollbars were jumping too far when pressing increment/decrement buttons because it was attempting scroll.applyPageFromCoord. Blocked that case.
Added safety checks to button repeater fix to prevent unintended multi-firing in timing corner cases.