### PR TITLE
check if directory exists before reading it

### DIFF
--- a/haxe/ui/macros/MacroHelpers.hx
+++ b/haxe/ui/macros/MacroHelpers.hx
@@ -179,7 +179,7 @@ class MacroHelpers {
                 break;
             }
         }
-        if (exclude == true) {
+        if (exclude == true || ! sys.FileSystem.exists(path)) {
             return;
         }
 


### PR DESCRIPTION
I had an issue that cacheClassPathEntries throws an exception because it tried to read a directory haxe/extraLib which was not on my machine. I am not sure where it came from, but anyway we are save here to check if the directory we are going to read exists