### PR TITLE
Fix compatibility with latest Haxe dev

### DIFF
--- a/haxe/ui/macros/ModuleMacros.hx
+++ b/haxe/ui/macros/ModuleMacros.hx
@@ -60,6 +60,10 @@ class ModuleMacros {
                 var types:Array<haxe.macro.Type> = MacroHelpers.typesFromClassOrPackage(s.className, s.classPackage);
                 if (types != null) {
                     for (t in types) {
+                        if (!t.match(TInst(_))) {
+                            continue;
+                        }
+
                         var scriptType = new ClassBuilder(t);
                         if (scriptType.isPrivate == true) {
                             continue;


### PR DESCRIPTION
Without this, compilation fails with the following:

    std/haxe/macro/MacroStringTools.hx:86: characters 84-89 : Cannot use abstract as value

which comes from `haxe/ui/macros/ModuleMacros.hx:86`. The macro was trying to generate a `addStaticClass()` call with `MessageBoxType`, which is an abstract, not a class.

See also: HaxeFoundation/haxe#8550