### PR TITLE
Absolute path for FileResource

### DIFF
--- a/haxe/ui/parsers/ui/resolvers/FileResourceResolver.hx
+++ b/haxe/ui/parsers/ui/resolvers/FileResourceResolver.hx
@@ -29,8 +29,7 @@ class FileResourceResolver extends ResourceResolver {
         var data:String = null;
         if (FileSystem.exists(f)) {
             data = StringUtil.replaceVars(File.getContent(f), _params);
-        }
-        else if(FileSystem.exists(r)){
+        }else if(FileSystem.exists(r)){
             data = StringUtil.replaceVars(File.getContent(r), _params);
         }
         if (data == null) {

--- a/haxe/ui/parsers/ui/resolvers/FileResourceResolver.hx
+++ b/haxe/ui/parsers/ui/resolvers/FileResourceResolver.hx
@@ -30,6 +30,9 @@ class FileResourceResolver extends ResourceResolver {
         if (FileSystem.exists(f)) {
             data = StringUtil.replaceVars(File.getContent(f), _params);
         }
+        else if(FileSystem.exists(r)){
+            data = StringUtil.replaceVars(File.getContent(r), _params);
+        }
         if (data == null) {
             trace("WARNING: Could not find file: " + f);
         }


### PR DESCRIPTION
If the rootDir+r is not a valid path; check if the r value supplied for the resource is a path on system.