### PR TITLE
Change clearing to prevent infinite loop

### DIFF
--- a/haxe/ui/data/ArrayDataSource.hx
+++ b/haxe/ui/data/ArrayDataSource.hx
@@ -37,7 +37,7 @@ class ArrayDataSource<T> extends DataSource<T> {
         _array.remove(item);
         return item;
     }
-    private override function handleClear():Void{
+    private override function handleClear() {
         while (_array.length > 0) {
             _array.pop();
         }

--- a/haxe/ui/data/ArrayDataSource.hx
+++ b/haxe/ui/data/ArrayDataSource.hx
@@ -37,6 +37,11 @@ class ArrayDataSource<T> extends DataSource<T> {
         _array.remove(item);
         return item;
     }
+    private override function handleClear():Void{
+        while (_array.length > 0) {
+            _array.pop();
+        }
+    }
 
     private override function handleUpdateItem(index:Int, item:T):T {
         return _array[index] = item;

--- a/haxe/ui/data/DataSource.hx
+++ b/haxe/ui/data/DataSource.hx
@@ -119,7 +119,7 @@ class DataSource<T> {
         return null;
     }
 
-    private function handleClear():Void {
+    private function handleClear() {
     }
 
     private function handleUpdateItem(index:Int, item:T):T {

--- a/haxe/ui/data/DataSource.hx
+++ b/haxe/ui/data/DataSource.hx
@@ -81,9 +81,7 @@ class DataSource<T> {
     public function clear() {
         var o = _allowCallbacks;
         _allowCallbacks = false;
-        while (size > 0) {
-            remove(get(0));
-        }
+        handleClear();
         _allowCallbacks = o;
         handleChanged();
     }
@@ -119,6 +117,9 @@ class DataSource<T> {
 
     private function handleRemoveItem(item:T):T {
         return null;
+    }
+
+    private function handleClear():Void {
     }
 
     private function handleUpdateItem(index:Int, item:T):T {

--- a/haxe/ui/data/ListDataSource.hx
+++ b/haxe/ui/data/ListDataSource.hx
@@ -68,6 +68,10 @@ class ListDataSource<T> extends DataSource<T> {
         return item;
     }
 
+    private override function handleClear():Void {
+        _array.clear();
+    }
+
     private override function handleUpdateItem(index:Int, item:T):T {
         var i = 0;
         var r = null;

--- a/haxe/ui/data/ListDataSource.hx
+++ b/haxe/ui/data/ListDataSource.hx
@@ -68,7 +68,7 @@ class ListDataSource<T> extends DataSource<T> {
         return item;
     }
 
-    private override function handleClear():Void {
+    private override function handleClear() {
         _array.clear();
     }
 


### PR DESCRIPTION
DataSources can have infinite loops when trying to clear the data; This happens only when using a transformer that returns a different type then the type that is contained in the DataSource(i.e. a String in the DataSource will be transformed to a {text: i } so when we call clear on the DataSource we can't remove each item since the item returned with get will be transformed). 