### PR TITLE
Increase invalidateCount to 100 to fix invalidate errors on OSX

### DIFF
--- a/haxe/ui/core/ComponentValidation.hx
+++ b/haxe/ui/core/ComponentValidation.hx
@@ -88,7 +88,7 @@ class ComponentValidation extends ComponentEvents {
             _invalidateCount++;
 
             //we track the invalidate count to check if we are in an infinite loop or serious bug because it affects performance
-            if (this._invalidateCount >= 10) {
+            if (this._invalidateCount >= 100) {
                 throw 'The validation queue returned too many times during validation. This may be an infinite loop. Try to avoid doing anything that calls invalidate() during validation.';
             }
 


### PR DESCRIPTION
This fixes OSX and mobile device issues that use touch input that fire many more scroll and mouse events. Before this fix almost every HTML5 build with scroll views breaks after a few seconds of scrolling with a OSX touchpad.