### PR TITLE
Screen & HaxeUIApp return component consistent w/ Component's methods

### DIFF
--- a/haxe/ui/HaxeUIApp.hx
+++ b/haxe/ui/HaxeUIApp.hx
@@ -86,16 +86,16 @@ class HaxeUIApp extends AppImpl {
         }
     }
     
-    public function addComponent(component:Component) {
-        Screen.instance.addComponent(component);
+    public function addComponent(component:Component):Component {
+        return Screen.instance.addComponent(component);
     }
 
-    public function removeComponent(component:Component) {
-        Screen.instance.removeComponent(component);
+    public function removeComponent(component:Component):Component {
+        return Screen.instance.removeComponent(component);
     }
 
-    public function setComponentIndex(child:Component, index:Int) {
-        Screen.instance.setComponentIndex(child, index);
+    public function setComponentIndex(child:Component, index:Int):Component {
+        return Screen.instance.setComponentIndex(child, index);
     }
     
     private override function buildPreloadList():Array<PreloadItem> {

--- a/haxe/ui/backend/ScreenBase.hx
+++ b/haxe/ui/backend/ScreenBase.hx
@@ -49,10 +49,12 @@ class ScreenBase {
         return 0;
     }
     
-    public function addComponent(component:Component) {
+    public function addComponent(component:Component):Component {
+		return component;
     }
     
-    public function removeComponent(component:Component) {
+    public function removeComponent(component:Component):Component {
+		return component;
     }
     
     private function handleSetComponentIndex(child:Component, index:Int) {

--- a/haxe/ui/core/Screen.hx
+++ b/haxe/ui/core/Screen.hx
@@ -4,6 +4,7 @@ import haxe.ui.backend.ScreenImpl;
 import haxe.ui.containers.dialogs.Dialog;
 import haxe.ui.containers.dialogs.Dialog.DialogButton;
 import haxe.ui.containers.dialogs.MessageBox.MessageBoxType;
+import haxe.ui.core.Component;
 import haxe.ui.events.UIEvent;
 import haxe.ui.focus.FocusManager;
 import haxe.ui.util.EventMap;
@@ -33,7 +34,7 @@ class Screen extends ScreenImpl {
         _eventMap = new EventMap();
     }
 
-    public override function addComponent(component:Component) {
+    public override function addComponent(component:Component):Component {
         super.addComponent(component);
         #if !haxeui_android
         component.ready();
@@ -43,21 +44,24 @@ class Screen extends ScreenImpl {
             FocusManager.instance.pushView(component);
             component.registerEvent(UIEvent.RESIZE, _onRootComponentResize);    //refresh vh & vw
         }
+		return component;
     }
 
-    public override function removeComponent(component:Component) {
+    public override function removeComponent(component:Component):Component {
         super.removeComponent(component);
         component.depth = -1;
         rootComponents.remove(component);
         component.unregisterEvent(UIEvent.RESIZE, _onRootComponentResize);
+		return component;
     }
 
-    public function setComponentIndex(child:Component, index:Int) {
+    public function setComponentIndex(child:Component, index:Int):Component {
         if (index >= 0 && index <= rootComponents.length) {
             handleSetComponentIndex(child, index);
             rootComponents.remove(child);
             rootComponents.insert(index, child);
         }
+		return child;
     }
 
     public function refreshStyleRootComponents() {


### PR DESCRIPTION
Fixes haxeui-core issue #211: Screen & HaxeUIApp now return component for addComponent, removeComponent, and setComponentIndex.