### PR TITLE
Don't use findComponent in event binding annotation

### DIFF
--- a/haxe/ui/macros/helpers/FieldBuilder.hx
+++ b/haxe/ui/macros/helpers/FieldBuilder.hx
@@ -138,6 +138,19 @@ class FieldBuilder {
         }
         return n;
     }
+
+    public function getMetaByIndex(name:String, index:Int = 0):MetadataEntry {
+        var n = 0;
+        for (m in field.meta) {
+            if (m.name == name || m.name == ':${name}') {
+                if (n == index) {
+                    return m;
+                }
+                n++;
+            }
+        }
+        return null;
+    }
     
     public function getMetaValueString(name:String, paramIndex:Int = 0, metaIndex:Int = 0):String {
         var n = 0;


### PR DESCRIPTION
Use the generated fields for components with id directly instead of findComponent. Will result in compile time error if field for such component doesn't exist.

Use expression directly instead of converting to string and back to expression. In case of error this allows compiler to  point at expression inside annotation instead of macro and whole class.

Improve the error message when the pattern for `@:bind` arguments doesn't match expected pattern.

Property binding mostly untouched, but with slightly less manual string manipulation.