### PR TITLE
dynamic class creation pathname fix

### DIFF
--- a/haxe/ui/macros/ModuleMacros.hx
+++ b/haxe/ui/macros/ModuleMacros.hx
@@ -323,10 +323,9 @@ class ModuleMacros {
             trace("WARNING: Could not find path " + resolvedPath);
         }
         
-        filePath = Path.normalize(resolvedPath);
-        var fullPath = filePath;
+        var fullPath = Path.normalize(resolvedPath);
         if (root != null) {
-            filePath = StringTools.replace(filePath, root, "");
+            filePath = StringTools.replace(fullPath, root, "");
         }
         
         var fileParts = filePath.split("/");


### PR DESCRIPTION
What was broken: 
Components weren't being added in the Kha target to the correct namespaces. They were using the "absolute" address for their package lineage (something like _drive.users.documents.project.xy.z_) instead of `assets.ui.Component`.

What I did:
Found this starting with this post: https://community.haxeui.org/t/issues-with-module-generating-classes/91/9

This fix allows for the logic from commit a02d10693e354dd02e21368e4ba0c063de75883e to work again when using relative paths. Specifically for the Kha target - where we commonly use "../Assets/..". 

From what I understood, it looks like 00b925fda234ab44386885a7af5c4c3c6e636e33 was added a few months later but is where the package path code broke again. In my change I assumed we didn't actually need to change the `filePath` variable that was passed in and it looks like everything that needs the `fullPath` references that and not filePath. 

I left line 329 in there and replaced filePath with fullPath as I assumed that would keep the same functionality - however I do not know how to create the test case for `root != null`. 