### PR TITLE
haxe 4.2 needs Variant to be marked as transitive

### DIFF
--- a/haxe/ui/util/Variant.hx
+++ b/haxe/ui/util/Variant.hx
@@ -16,6 +16,7 @@ enum VariantType {
     VT_ImageData(s:ImageData);
 }
 
+@:transitive
 abstract Variant(VariantType) from VariantType {
     // ************************************************************************************************************
     // STRINGS


### PR DESCRIPTION
the @:transitive has no meaning in haxe 4.1 or lower, so this change is backward compatible