### PR TITLE
move image loading implementation into AssetsBase

### DIFF
--- a/haxe/ui/backend/AssetsBase.hx
+++ b/haxe/ui/backend/AssetsBase.hx
@@ -25,6 +25,28 @@ class AssetsBase {
         callback(null);
     }
 
+    public function imageFromFile(filename:String, callback:ImageInfo->Void) {
+        #if sys
+
+        if (sys.FileSystem.exists(filename) == false) {
+            callback(null);
+        }
+
+        try {
+            Toolkit.assets.imageFromBytes(sys.io.File.getBytes(filename), callback);
+        } catch (e:Dynamic) {
+            trace("Problem loading image file: " + e);
+            callback(null);
+        }
+
+        #else
+
+        trace('WARNING: cant load from file system on non-sys targets [${filename}]');
+        callback(null);
+
+        #end
+    }
+
     private function getFontInternal(resourceId:String, callback:FontInfo->Void) {
         callback(null);
     }

--- a/haxe/ui/util/ImageLoader.hx
+++ b/haxe/ui/util/ImageLoader.hx
@@ -18,7 +18,7 @@ class ImageLoader {
             if (StringTools.startsWith(stringResource, "http://") || StringTools.startsWith(stringResource, "https://")) {
                 loadFromHttp(stringResource, callback);
             } else if (StringTools.startsWith(stringResource, "file://")) {
-                loadFromFile(stringResource.substr(7), callback);
+                Toolkit.assets.imageFromFile(stringResource.substr(7), callback);
             } else { // assume asset
                 Toolkit.assets.getImage(stringResource, callback);
             }
@@ -108,28 +108,6 @@ class ImageLoader {
             callback(null);
         }
         http.request();
-
-        #end
-    }
-
-    private function loadFromFile(filename, callback:ImageInfo->Void) {
-        #if sys
-
-        if (sys.FileSystem.exists(filename) == false) {
-            callback(null);
-        }
-
-        try {
-            Toolkit.assets.imageFromBytes(sys.io.File.getBytes(filename), callback);
-        } catch (e:Dynamic) {
-            trace("Problem loading image file: " + e);
-            callback(null);
-        }
-
-        #else
-
-        trace('WARNING: cant load from file system on non-sys targets [${filename}]');
-        callback(null);
 
         #end
     }


### PR DESCRIPTION
I wanted to use `kha.Assets.loadImageFromPath()` instead of your current implementation so it works properly on the debug-html5 target and isn't dependent on haxe's `sys` API any longer. So i moved the function into AssetsBase to override it in the Kha backend.

See https://github.com/haxeui/haxeui-kha/pull/50