### PR TITLE
fix compilation for -D js-es=6

### DIFF
--- a/haxe/ui/parsers/ui/ComponentParser.hx
+++ b/haxe/ui/parsers/ui/ComponentParser.hx
@@ -5,12 +5,12 @@ import haxe.ui.parsers.ui.resolvers.ResourceResolver;
 #if (haxe_ver >= 4.1)
 
 class ComponentParserException extends haxe.Exception {
-    public var fileName:String = null;
-    public var original:haxe.Exception = null;
+    public var fileName:String;
+    public var original:haxe.Exception;
     public function new(message:String, fileName:String, original:haxe.Exception, ?previous:haxe.Exception, ?native:Any):Void {
+        super(message, previous, native);
         this.fileName = fileName;
         this.original = original;
-        super(message, previous, native);
     }
 }
 


### PR DESCRIPTION
Haxe codegen for js-es:6 is a bit broken and expects the super call first before any other operation (even field initializers won't work ^^) in the new function - otherwise it can't compile.