### PR TITLE
improve locale handling in BindingManager

### DIFF
--- a/haxe/ui/binding/BindingManager.hx
+++ b/haxe/ui/binding/BindingManager.hx
@@ -251,9 +251,9 @@ class BindingManager {
         return bindingScript.script == script;
     }
     
-    private function isLocaleString(script:String):Bool {
-        return LocaleManager.instance.hasString(StringTools.trim(script.split(",")[0]));
-    }
+//    private function isLocaleString(script:String):Bool {
+//        return LocaleManager.instance.hasString(StringTools.trim(script.split(",")[0]));
+//    }
     
     private function buildLocaleScript(script:String):String {
         if (script == null) {
@@ -326,7 +326,7 @@ class BindingManager {
             var after:String = copy.substr(n2 + 1, copy.length);
             var script:String = copy.substr(n1 + 2, n2 - n1 - 2);
 
-            var result:Any = exec(script, prop, t);
+            var result:Any = exec(script, prop, t, prop.languageBinding);
 
             copy = before + result + after;
             n1 = copy.indexOf("${");
@@ -335,8 +335,8 @@ class BindingManager {
     }
 
     private var interp:ScriptInterp = new ScriptInterp();
-    private function exec(script:String, prop:PropertyInfo, t:Component):Dynamic {
-        if (isLocaleString(script)) {
+    private function exec(script:String, prop:PropertyInfo, t:Component, isLocaleString:Bool):Dynamic {
+        if (isLocaleString) {
             script = buildLocaleScript(script);
         }
         var parser = new Parser();


### PR DESCRIPTION
The main problem i had was the program crashing for undefined `msgid`, which happens quite often while developing (at least for me). `isLocaleString(str)` would return `false` (as i hadn't added all `msgid` to the PO files yet) and in turn the code would try to run as plain hscript instead of `lookupLocaleString(str)`. If you have id's that contain spaces `msgid = "some id with space"`, hscript would throw an error in Parser.hx for that.

```
	function unexpected( tk ) : Dynamic {
		error(EUnexpected(tokenString(tk)),tokenMin,tokenMax);
		return null;
	}
```

As somewhat of a bonus, it also display's the actual `msgid` instead of just `null` which is pretty cool, but i have no clue why that happens :sweat_smile: 

I hope it doesn't break anything, but with my test projects it seems to work fine.
