### PR TITLE
fix null access error in moveComponent functions

### DIFF
--- a/haxe/ui/core/ComponentContainer.hx
+++ b/haxe/ui/core/ComponentContainer.hx
@@ -77,7 +77,7 @@ class ComponentContainer extends ComponentCommon implements IClonable<ComponentC
     }
 
     public function moveComponentToBack() {
-        if (parentComponent == null && parentComponent.numComponents <= 1) {
+        if (parentComponent == null || parentComponent.numComponents <= 1) {
             return;
         }
         
@@ -85,7 +85,7 @@ class ComponentContainer extends ComponentCommon implements IClonable<ComponentC
     }
 
     public function moveComponentBackward() {
-        if (parentComponent == null && parentComponent.numComponents <= 1) {
+        if (parentComponent == null || parentComponent.numComponents <= 1) {
             return;
         }
         
@@ -98,7 +98,7 @@ class ComponentContainer extends ComponentCommon implements IClonable<ComponentC
     }
     
     public function moveComponentToFront() {
-        if (parentComponent == null && parentComponent.numComponents <= 1) {
+        if (parentComponent == null || parentComponent.numComponents <= 1) {
             return;
         }
         
@@ -106,7 +106,7 @@ class ComponentContainer extends ComponentCommon implements IClonable<ComponentC
     }
 
     public function moveComponentFrontward() {
-        if (parentComponent == null && parentComponent.numComponents <= 1) {
+        if (parentComponent == null || parentComponent.numComponents <= 1) {
             return;
         }
         


### PR DESCRIPTION
fix moveComponent* functions... if parentComponent is null, then accessing numComponents causes a null access error... pretty sure your intention here was || instead of &&?
```
        if (parentComponent == null && parentComponent.numComponents <= 1) {
            return;
        }
```

functions affected:
- moveComponentToBack()
- moveComponentBackward()
- moveComponentToFront()
- moveComponentFrontward()