### PR TITLE
fix dropdowns and dialogs appearing underneath other components?

### DIFF
--- a/haxe/ui/backend/DialogBase.hx
+++ b/haxe/ui/backend/DialogBase.hx
@@ -109,6 +109,7 @@ class DialogBase extends Box {
                 dp.addComponent(_overlay);
             } else {
                 Screen.instance.addComponent(_overlay);
+                Screen.instance.setComponentIndex(_overlay, Screen.instance.rootComponents.length);
             }
         }
         createButtons();
@@ -117,6 +118,7 @@ class DialogBase extends Box {
             dp.addComponent(this);
         } else {
             Screen.instance.addComponent(this);
+            Screen.instance.setComponentIndex(this, Screen.instance.rootComponents.length);
         }
         this.syncComponentValidation();
         if (autoHeight == false) {

--- a/haxe/ui/components/DropDown.hx
+++ b/haxe/ui/components/DropDown.hx
@@ -579,6 +579,16 @@ class DropDownEvents extends ButtonEvents {
             }
         }
 
+        // bug: dropdowns don't actually appear if there's multiple root components re-ordered on Screen.instance?
+        // solution: force overlay and wrapper to actually be on top
+        if (_overlay != null) {
+            Screen.instance.setComponentIndex(_overlay, Screen.instance.rootComponents.length);
+        }
+        if (_wrapper != null) {
+            Screen.instance.setComponentIndex(_wrapper, Screen.instance.rootComponents.length);
+        }
+
+
         Screen.instance.registerEvent(MouseEvent.MOUSE_DOWN, onScreenMouseDown);
         Screen.instance.registerEvent(MouseEvent.RIGHT_MOUSE_DOWN, onScreenMouseDown);
     }


### PR DESCRIPTION
bug: if there's multiple root components on Screen.instance already, dropdowns and dialogs are somehow added underneath? or something like that?

quick-fix: force the dropdown and dialog's _overlay and _wrapper components to be on top of rootComponents sorting array