### PR TITLE
Correcting dialogs with a dialog parent 

### DIFF
--- a/haxe/ui/backend/DialogBase.hx
+++ b/haxe/ui/backend/DialogBase.hx
@@ -140,7 +140,13 @@ class DialogBase extends Box {
                 }
             }
             if (dp != null) {
-                dp.addComponent(_overlay);
+                includeInLayout = false;
+        		_overlay.includeInLayout = false;
+        		_overlay.screenTop = dp.screenTop;
+        		_overlay.screenLeft = dp.screenLeft;
+        		_overlay.height = dp.height;
+        		_overlay.width = dp.width;
+        		dp.addComponent(_overlay);
             } else {
                 Screen.instance.addComponent(_overlay);
             }


### PR DESCRIPTION
overlay wouldn't show and dialog would be in included in layout for children size calculation