### PR TITLE
Returning dropdown value even when not ready

### DIFF
--- a/haxe/ui/components/DropDown.hx
+++ b/haxe/ui/components/DropDown.hx
@@ -160,6 +160,9 @@ private class SelectedItemBehaviour extends DynamicDataBehaviour  {
     }
 
     public override function getDynamic():Dynamic {
+        if (_component.isReady == false) {
+            return _value;
+        }
         var handler:IDropDownHandler = cast(_component._compositeBuilder, DropDownBuilder).handler;
         return handler.selectedItem;
     }


### PR DESCRIPTION
Otherwise, doing something like
```
dropdown.selectedItem = {text:"Item 3"};
        trace(dropdown.selectedItem);
```
 traces null