### PR TITLE
Add path of saved file to SaveFileDialog callback

### DIFF
--- a/haxe/ui/backend/SaveFileDialogBase.hx
+++ b/haxe/ui/backend/SaveFileDialogBase.hx
@@ -14,13 +14,14 @@ typedef SaveFileDialogOptions = {
 
 class SaveFileDialogBase {
     public var saveResult:Bool = false;
-    public var callback:DialogButton->Bool->Void = null;
+    public var fullPath:String = null;
+    public var callback:DialogButton->Bool->String->Void = null;
     public var onDialogClosed:DialogEvent->Void = null;
     
     public var fileInfo:FileInfo = null;
     
     
-    public function new(options:SaveFileDialogOptions = null, callback:DialogButton->Bool->Void = null) {
+    public function new(options:SaveFileDialogOptions = null, callback:DialogButton->Bool->String->Void = null) {
         this.options = options;
         this.callback = callback;
     }
@@ -49,7 +50,7 @@ class SaveFileDialogBase {
     private function dialogConfirmed() {
         saveResult = true;
         if (callback != null) {
-            callback(DialogButton.OK, saveResult);
+            callback(DialogButton.OK, saveResult, fullPath);
         }
         if (onDialogClosed != null) {
             var event = new DialogEvent(DialogEvent.DIALOG_CLOSED, false, saveResult);
@@ -61,7 +62,7 @@ class SaveFileDialogBase {
     private function dialogCancelled() {
         saveResult = false;
         if (callback != null) {
-            callback(DialogButton.CANCEL, saveResult);
+            callback(DialogButton.CANCEL, saveResult, null);
         }
         if (onDialogClosed != null) {
             var event = new DialogEvent(DialogEvent.DIALOG_CLOSED, false, saveResult);

--- a/haxe/ui/containers/dialogs/Dialogs.hx
+++ b/haxe/ui/containers/dialogs/Dialogs.hx
@@ -129,7 +129,7 @@ class Dialogs {
         }, options);
     }
     
-    public static function saveFile(callback:DialogButton->Bool->Void, fileInfo:FileInfo, options:SaveFileDialogOptions = null) {
+    public static function saveFile(callback:DialogButton->Bool->String->Void, fileInfo:FileInfo, options:SaveFileDialogOptions = null) {
         var dialog = new SaveFileDialog();
         dialog.callback = callback;
         dialog.options = options;
@@ -137,27 +137,27 @@ class Dialogs {
         dialog.show();
     }
     
-    public static function saveBinaryFile(title:String = null, fileTypes:Array<FileDialogExtensionInfo> = null, fileInfo:FileInfo, callback:Bool->Void) {
+    public static function saveBinaryFile(title:String = null, fileTypes:Array<FileDialogExtensionInfo> = null, fileInfo:FileInfo, callback:Bool->String->Void) {
         var options:SaveFileDialogOptions = {
             writeAsBinary: true,
             extensions: fileTypes,
             title: title
         }
 
-        saveFile(function(button, result) {
-            callback(result);
+        saveFile(function(button, result, path) {
+            callback(result, path);
         }, fileInfo, options);
     }
     
-    public static function saveTextFile(title:String = null, fileTypes:Array<FileDialogExtensionInfo> = null, fileInfo:FileInfo, callback:Bool->Void) {
+    public static function saveTextFile(title:String = null, fileTypes:Array<FileDialogExtensionInfo> = null, fileInfo:FileInfo, callback:Bool->String->Void) {
         var options:SaveFileDialogOptions = {
             writeAsBinary: false,
             extensions: fileTypes,
             title: title
         }
 
-        saveFile(function(button, result) {
-            callback(result);
+        saveFile(function(button, result, path) {
+            callback(result, path);
         }, fileInfo, options);
     }
 }


### PR DESCRIPTION
Stores the saved file's path in the SaveFileDialog's instance, to match how saveResult functions.
The callback becomes a DialogButton->Bool->String->Void.
If the dialog is canceled or the backend doesn't/can't provide a path, null is returned.
This is a breaking change as callbacks must be modified to expect the third argument.
This has downstream implications because backend impls may need to do the same.
At the very least, Heaps does and will be handled in another PR.
