### PR TITLE
stop compiler complaining about uninitialized variable use

### DIFF
--- a/haxe/ui/util/Color.hx
+++ b/haxe/ui/util/Color.hx
@@ -151,7 +151,7 @@ abstract Color(Int) from Int {
     }
 
     static public function fromComponents(r:Int, g:Int, b:Int, a:Int):Color {
-        var result:Color;
+        var result:Color = 0;
         return result.set(r, g, b, a);
     }
 


### PR DESCRIPTION
Application compiles, but this error keeps popping up every time i launch a haxeui project. Shouldn't cause any breaking changes