### PR TITLE
Fix null object reference

### DIFF
--- a/haxe/ui/focus/FocusManager.hx
+++ b/haxe/ui/focus/FocusManager.hx
@@ -187,7 +187,7 @@ class FocusManager extends FocusManagerImpl {
         }
         var currentFocus = null;
         
-        if (@:privateAccess c._isDisposed == true) {
+        if (c == null || @:privateAccess c._isDisposed == true) {
             return null;
         }
         


### PR DESCRIPTION
I encountered a null object reference on this line in the following circumstance

- Create a HaxeUI and set focus to an element such as a text field.
- Close the Haxe UI (such as by switching to another state in HaxeFlixel)
- Press TAB

The focused element was destroyed and thus a crash occurs. I resolved the crash by having the UI use the same behavior as when the element is marked as disposed.