### PR TITLE
Update KeyValueParser.hx

### DIFF
--- a/haxe/ui/parsers/locale/KeyValueParser.hx
+++ b/haxe/ui/parsers/locale/KeyValueParser.hx
@@ -10,7 +10,7 @@ class KeyValueParser extends LocaleParser {
 	
 	public override function parse(data:String):Map<String, String> {
 		if (PARSER_SEPARATOR == "") {
-			throw "separator, comment needs implementation";
+			throw "PARSER_SEPARATOR needs implementation in " + Type.getClassName(Type.getClass(this));
 		}
 		
 		var result:Map<String, String> = new Map<String, String>();


### PR DESCRIPTION
Better exception message when PARSER_SEPARATOR is not set in child class.