### PR TITLE
Rename instances of application.xml to Project.xml

### DIFF
--- a/cli/projects/openfl-shared/project.json
+++ b/cli/projects/openfl-shared/project.json
@@ -2,6 +2,6 @@
     "name": "openfl-shared",
     "type": "template",
     "templates": [
-        { "src": "application.xml", "dst": "${target}/application.xml"}
+        { "src": "Project.xml", "dst": "${target}/Project.xml"}
     ]
 }

--- a/cli/src/builds/openfl/OpenFLBuild.hx
+++ b/cli/src/builds/openfl/OpenFLBuild.hx
@@ -4,7 +4,7 @@ import builds.ProcessBuild;
 
 class OpenFLBuild extends ProcessBuild {
     public function new() {
-        super("openfl", ["application.xml"]);
+        super("openfl", ["Project.xml"]);
     }
 
     private override function args(params:Params):Array<String> {
@@ -18,6 +18,6 @@ class OpenFLBuild extends ProcessBuild {
         } else if (Util.mapContains("android", params.additional)) {
             target = "android";
         }
-        return ["build", "application.xml", target];
+        return ["build", "Project.xml", target];
     }
 }

--- a/cli/src/descriptors/OpenFlApplicationXml.hx
+++ b/cli/src/descriptors/OpenFlApplicationXml.hx
@@ -33,7 +33,7 @@ class OpenFlApplicationXml extends Descriptor {
     public override function find(path:String):Bool {
         var contents = FileSystem.readDirectory(path);
         for (c in contents) {
-            if (FileSystem.isDirectory(path + "/" + c) == false && (c == "application.xml" || c == "project.xml")) {
+            if (FileSystem.isDirectory(path + "/" + c) == false && (c == "Project.xml" || c == "project.xml")) {
                 load(path + "/" + c);
                 return true;
             }

--- a/cli/src/descriptors/OpenFlApplicationXml.hx
+++ b/cli/src/descriptors/OpenFlApplicationXml.hx
@@ -33,7 +33,7 @@ class OpenFlApplicationXml extends Descriptor {
     public override function find(path:String):Bool {
         var contents = FileSystem.readDirectory(path);
         for (c in contents) {
-            if (FileSystem.isDirectory(path + "/" + c) == false && (c == "Project.xml" || c == "project.xml")) {
+            if (FileSystem.isDirectory(path + "/" + c) == false && c == "Project.xml") {
                 load(path + "/" + c);
                 return true;
             }

--- a/cli/templates/openfl-flash-develop/openfl.hxproj
+++ b/cli/templates/openfl-flash-develop/openfl.hxproj
@@ -4,7 +4,7 @@
   <output>
     <movie outputType="CustomBuild" />
     <movie input="" />
-    <movie path="application.xml" />
+    <movie path="Project.xml" />
     <movie fps="60" />
     <movie width="800" />
     <movie height="600" />


### PR DESCRIPTION
This keeps the Lime VSC extension from giving errors due to not detecting the `application.xml` file, as it can only detect files named `Project.xml`. Also removed the statement allowing `project.xml || Project.xml`, as it is redundant. I may have edited unnecessary files, tell me if I did.