### PR TITLE
fix fadeOut param name in doc

### DIFF
--- a/haxe/ui/core/Component.hx
+++ b/haxe/ui/core/Component.hx
@@ -1143,7 +1143,7 @@ class Component extends ComponentImpl implements IValidating {
     /**
      * Applies a fade effect which turns this component from visible to invisible.
      * @param onEnd A function to dispatch when the fade completes
-     * @param show When enabled, ensures that this component is actually invisible when the fade completes.
+     * @param hide When enabled, ensures that this component is actually invisible when the fade completes.
      */
     public function fadeOut(onEnd:Void->Void = null, hide:Bool = true) {
         if (onEnd != null || hide == true) {


### PR DESCRIPTION
tiny doc change to make code hinting match the function arg