### PR TITLE
add userData to TabbarButton

### DIFF
--- a/haxe/ui/components/TabBar.hx
+++ b/haxe/ui/components/TabBar.hx
@@ -447,6 +447,7 @@ private class Builder extends CompositeBuilder {
         button.tooltip = child.tooltip;
         if ((child is Button)) {
             button.icon = cast(child, Button).icon;
+            button.userData = cast(child, Button).userData;
         }
         button.closable = _tabbar.closable;
         if (_tabbar.buttonWidth != null) {

--- a/haxe/ui/components/TabBar.hx
+++ b/haxe/ui/components/TabBar.hx
@@ -445,9 +445,9 @@ private class Builder extends CompositeBuilder {
         button.id = child.id;
         button.text = child.text;
         button.tooltip = child.tooltip;
+        button.userData = child.userData;
         if ((child is Button)) {
             button.icon = cast(child, Button).icon;
-            button.userData = cast(child, Button).userData;
         }
         button.closable = _tabbar.closable;
         if (_tabbar.buttonWidth != null) {


### PR DESCRIPTION
When creating buttons dynamically for the Tabbar component we are unable to assign an onClick event because internally it's recreating the button.  This forces the user to register events by retrieving the Tabbar's buttons via `getTab` and because of this there are some cases where we are unable to pass an onClick event important data. 

To solve this problem this PR assigns the userData from the button passed into addComponent into the TabbarButton we create internally.