### PR TITLE
fix ScrollMode not unregistering mousedown event

### DIFF
--- a/haxe/ui/containers/ScrollView.hx
+++ b/haxe/ui/containers/ScrollView.hx
@@ -632,7 +632,7 @@ class ScrollViewEvents extends haxe.ui.events.Events {
 
         if (_scrollview.scrollMode == ScrollMode.DRAG || _scrollview.scrollMode == ScrollMode.INERTIAL) {
             registerEvent(MouseEvent.MOUSE_DOWN, onMouseDown);
-        } else if (hasEvent(MouseEvent.MOUSE_DOWN, onMouseDown) == false) {
+        } else if (hasEvent(MouseEvent.MOUSE_DOWN, onMouseDown)) {
             unregisterEvent(MouseEvent.MOUSE_DOWN, onMouseDown);
         }
 


### PR DESCRIPTION
I'm pretty sure the intended behavior when changing ScrollMode to normal is that its supposed to unregister the mousedown event so that dragging to scroll is no longer possible.