### PR TITLE
Localization strings for form and messagebox

### DIFF
--- a/haxe/ui/_module/locale/en/form-strings.properties
+++ b/haxe/ui/_module/locale/en/form-strings.properties
@@ -1,0 +1,1 @@
+form.field.required=Field is required

--- a/haxe/ui/_module/locale/en/messagebox-strings.properties
+++ b/haxe/ui/_module/locale/en/messagebox-strings.properties
@@ -1,0 +1,4 @@
+messagebox.title.info=Info
+messagebox.title.question=Question
+messagebox.title.warning=Warning
+messagebox.title.error=Error

--- a/haxe/ui/_module/locale/pt/form-strings.properties
+++ b/haxe/ui/_module/locale/pt/form-strings.properties
@@ -1,0 +1,1 @@
+form.field.required=Campo obrigatório

--- a/haxe/ui/_module/locale/pt/messagebox-strings.properties
+++ b/haxe/ui/_module/locale/pt/messagebox-strings.properties
@@ -1,0 +1,4 @@
+messagebox.title.info=Informação
+messagebox.title.question=Pergunta
+messagebox.title.warning=Aviso
+messagebox.title.error=Erro

--- a/haxe/ui/containers/dialogs/MessageBox.hx
+++ b/haxe/ui/containers/dialogs/MessageBox.hx
@@ -41,15 +41,15 @@ class MessageBox extends MessageBoxBase {
         if (title == "Message") {
             switch (type) {
                 case MessageBoxType.TYPE_INFO:
-                    title = "Info";
+                    title = "{{messagebox.title.info}}";
                 case MessageBoxType.TYPE_QUESTION:
-                    title = "Question";
+                    title = "{{messagebox.title.question}}";
                 case MessageBoxType.TYPE_WARNING:
-                    title = "Warning";
+                    title = "{{messagebox.title.warning}}";
                 case MessageBoxType.TYPE_ERROR:
-                    title = "Error";
+                    title = "{{messagebox.title.error}}";
                 case MessageBoxType.TYPE_YESNO:
-                    title = "Question";
+                    title = "{{messagebox.title.question}}";
             }
         }
     }

--- a/haxe/ui/validators/RequiredValidator.hx
+++ b/haxe/ui/validators/RequiredValidator.hx
@@ -5,7 +5,7 @@ import haxe.ui.core.Component;
 class RequiredValidator extends Validator {
     public function new() {
         super();
-        invalidMessage = "Field is required";
+        invalidMessage = "{{form.field.required}}";
         invalidStyleName = "required-value";
     }
 


### PR DESCRIPTION
Added localization strings for form (required field) and messagebox (type titles) in EN and PT.