### PR TITLE
Update Frame.hx

### DIFF
--- a/haxe/ui/containers/Frame.hx
+++ b/haxe/ui/containers/Frame.hx
@@ -284,7 +284,7 @@ private class Layout extends DefaultLayout {
     public override function calcAutoSize(exclusions:Array<Component> = null):Size {
         var label = findComponent("frame-title", Label, false);
         var size = super.calcAutoSize(exclusions);
-        size.height += label.height / 2;
+        size.height += label.height;
         size.width -= paddingLeft;
         if (label != null && label.width > size.width) {
             var contents = findComponent("frame-contents", Box, false);


### PR DESCRIPTION
adjusting to allow neo borders

before frame open. empty. Good
![image](https://github.com/haxeui/haxeui-core/assets/2074385/747bd99d-b45e-4a32-a0ea-1881d4cc4a93)

before frame closed. Good
![image](https://github.com/haxeui/haxeui-core/assets/2074385/1d32d9bd-7192-4702-88ba-6283d50155f0)

with neo borders open. good
![image](https://github.com/haxeui/haxeui-core/assets/2074385/3602d3e7-98f4-46cb-acc9-ed1edecb29ea)

with neo borders closed. To be fixed with this PR
![image](https://github.com/haxeui/haxeui-core/assets/2074385/d8ddb684-c911-4294-b2b7-340ccde6554f)

After PR open
![image](https://github.com/haxeui/haxeui-core/assets/2074385/607e351f-7ffd-4828-9507-7c4b15867ce2)

After PR closed
![image](https://github.com/haxeui/haxeui-core/assets/2074385/9e91e277-0ce0-4568-97e8-20812ba6d582)

After PR neo closed
![image](https://github.com/haxeui/haxeui-core/assets/2074385/0b8d583a-a4fa-4951-858d-2a913b2767c9)

after PR neo  open
![image](https://github.com/haxeui/haxeui-core/assets/2074385/a8a25d3a-656b-4eda-af0e-58d48c49f967)

