### PR TITLE
More functionally correct TreeViewNode

### DIFF
--- a/haxe/ui/containers/TreeViewNode.hx
+++ b/haxe/ui/containers/TreeViewNode.hx
@@ -156,7 +156,6 @@ class TreeViewNode extends VBox {
 private class AddNode extends Behaviour {
     public override function call(param:Any = null):Variant {
         var node = new TreeViewNode();
-        node.parentNode = cast(_component, TreeViewNode);
         node.data = param;
         _component.addComponent(node);
         return node;
@@ -382,6 +381,7 @@ private class TreeViewNodeBuilder extends CompositeBuilder {
         }
         
         if ((child is TreeViewNode)) {
+            cast(child, TreeViewNode).parentNode = _node;
             if (_childContainer == null) {
                 _childContainer = new VBox();
                 if (_node.expanded == true) {
@@ -395,6 +395,31 @@ private class TreeViewNodeBuilder extends CompositeBuilder {
             }
             changeToExpandableRenderer();
             return _childContainer.addComponent(child);
+        }
+        
+        return null;
+    }
+	
+	public override function addComponentAt(child:Component, index:Int) {
+        if (child == _renderer || child == _childContainer) {
+            return null;
+        }
+        
+        if ((child is TreeViewNode)) {
+            cast(child, TreeViewNode).parentNode = _node;
+            if (_childContainer == null) {
+                _childContainer = new VBox();
+                if (_node.expanded == true) {
+                    _childContainer.show();
+                } else {
+                    _childContainer.hide();
+                }
+                _childContainer.addClass("treenode-child-container");
+                _childContainer.id = "treenode-child-container";
+                _node.addComponent(_childContainer);
+            }
+            changeToExpandableRenderer();
+            return _childContainer.addComponentAt(child,index);
         }
         
         return null;


### PR DESCRIPTION
Moved where `parentNode` is set from AddNode to `addComponent()` and `addComponentAt()` so it's more in line with RemoveNode and `removeComponent()`

added `addComponentAt()` override for enhanced sorting ability.


In theory this should work exactly the same as default, but should open up the door to things like drag and drop and more complex sorting