### PR TITLE
Minor fixes

### DIFF
--- a/haxe/ui/_module/locale/en/std-strings.properties
+++ b/haxe/ui/_module/locale/en/std-strings.properties
@@ -31,7 +31,7 @@ fri=Fri
 sat=Sat
 
 january=January
-febuary=Febuary
+febuary=February
 march=March
 april=April
 may=May

--- a/haxe/ui/_module/styles/default/pickers.css
+++ b/haxe/ui/_module/styles/default/pickers.css
@@ -70,7 +70,6 @@
     border-radius: 2px;
 
     background: $normal-background-color-start $normal-background-color-end vertical;
-    background: white;
 
     filter: $normal-inner-shadow;
 }

--- a/haxe/ui/components/ColorPicker.hx
+++ b/haxe/ui/components/ColorPicker.hx
@@ -349,6 +349,9 @@ private class HSVColorPickerImpl extends ColorPickerImpl {
             return;
         }
         var v = Std.parseFloat(inputHue.text);
+        if (Math.isNaN(v)) {
+            v = 0;
+        }
         if (v > 360) {
             v = 360;
         }
@@ -366,6 +369,9 @@ private class HSVColorPickerImpl extends ColorPickerImpl {
             return;
         }
         var v = Std.parseFloat(inputSaturation.text);
+        if (Math.isNaN(v)) {
+            v = 0;
+        }
         if (v > 100) {
             v = 100;
         }
@@ -383,6 +389,9 @@ private class HSVColorPickerImpl extends ColorPickerImpl {
             return;
         }
         var v = Std.parseFloat(inputValue.text);
+        if (Math.isNaN(v)) {
+            v = 0;
+        }
         if (v > 100) {
             v = 100;
         }
@@ -403,6 +412,9 @@ private class HSVColorPickerImpl extends ColorPickerImpl {
             return;
         }
         var v = Std.parseFloat(inputRed.text);
+        if (Math.isNaN(v)) {
+            v = 0;
+        }
         if (v > 255) {
             v = 255;
         }
@@ -420,6 +432,9 @@ private class HSVColorPickerImpl extends ColorPickerImpl {
             return;
         }
         var v = Std.parseFloat(inputGreen.text);
+        if (Math.isNaN(v)) {
+            v = 0;
+        }
         if (v > 255) {
             v = 255;
         }
@@ -437,6 +452,9 @@ private class HSVColorPickerImpl extends ColorPickerImpl {
             return;
         }
         var v = Std.parseFloat(inputBlue.text);
+        if (Math.isNaN(v)) {
+            v = 0;
+        }
         if (v > 255) {
             v = 255;
         }

--- a/haxe/ui/components/Switch.hx
+++ b/haxe/ui/components/Switch.hx
@@ -210,7 +210,7 @@ private class SwitchButtonSub extends InteractiveComponent {
     private function get_pos():Float {
         return _pos;
     }
-    private function set_pos(value:Float):Float {
+    @:keep private function set_pos(value:Float):Float {
         if (_pos == value) {
             return value;
         }

--- a/haxe/ui/util/MathUtil.hx
+++ b/haxe/ui/util/MathUtil.hx
@@ -4,6 +4,7 @@ class MathUtil {
     public static inline var MAX_INT:Int = 2147483647; // 2**31 - 1
     public static inline var MIN_INT:Int = -2147483648;
     public static inline var SIGNIFICANT_DECIMAL_DIGITS:Int = 7; // 32 bit floats have 24 bits precision  log10(2**24) ≈ 7.225  (for 64 bits it's 15)
+    public static inline var MAX_FLOAT_DIFFERENCE:Float = 0.0000001; // account for floating-point inaccuracy
 
     public static inline function distance(x1:Float, y1:Float, x2:Float, y2:Float):Float {
         return Math.sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
@@ -12,7 +13,7 @@ class MathUtil {
     public static inline function precision(v:Float):Int {
         var e = 1;
         var p = 0;
-        while (Math.round(v * e) / e != v) {
+        while (Math.abs((Math.round(v * e) / e) - v) > MAX_FLOAT_DIFFERENCE) {
             e *= 10;
             p++;
         }


### PR DESCRIPTION
- Fixed app getting stuck in a loop due to floating-point inaccuracy while validating a number stepper that has a decimal step value (happens on C++)
- Fixed `SwitchButtonSub.set_pos` not being kept by Dead Code Elimination, causing a bug after clicking on a switch
- Fixed bug when inputting invalid text in color picker HSV/RGB inputs (happens if you replace the entire text with a non-number character)
- Fixed month picker background being solid white regardless of theme
- Fixed "February" being misspelled as "Febuary" (the internal name is kept to not make a breaking change)