### PR TITLE
Fixed menus in menu bar not being disposed if they aren't currently on-screen

### DIFF
--- a/haxe/ui/containers/menus/MenuBar.hx
+++ b/haxe/ui/containers/menus/MenuBar.hx
@@ -285,6 +285,7 @@ private class Builder extends CompositeBuilder {
         super.destroy();
         for (menu in _menus) {
             Screen.instance.removeComponent(menu);
+            menu.disposeComponent();
         }
         _menus = null;
     }


### PR DESCRIPTION
After destroying a menu bar, the menus that are currently hidden aren't disposed, resulting in a crash if it dispatches any events (the menu bar event listener tries to find the index of it in `_menus`, but the array is null)