### PR TITLE
Button repeater action

### DIFF
--- a/haxe/ui/actions/ActionManager.hx
+++ b/haxe/ui/actions/ActionManager.hx
@@ -87,7 +87,12 @@ class ActionManager {
         if (actionEvent.canceled == false) {
             dispatch(new ActionEvent(ActionEvent.ACTION_START, action, false, Type.getClassName(Type.getClass(source))));
         }
-        if (actionEvent.repeater == true  && _repeatActions.exists(action) == false) {
+        if (actionEvent.repeater == true) {
+            if (_repeatActions.exists(action)) {
+                var info = _repeatActions.get(action);
+                info.timer.stop();
+                _repeatActions.remove(action);
+            }
             _repeatActions.set(action, {
                 type: action,
                 timer: new Timer(c.actionRepeatInterval, function() { // TODO: 100ms should probably be configurable

--- a/haxe/ui/components/Button.hx
+++ b/haxe/ui/components/Button.hx
@@ -662,7 +662,20 @@ class ButtonEvents extends haxe.ui.events.Events {
     private function onActionStart(event:ActionEvent) {
         switch (event.action) {
             case ActionType.PRESS | ActionType.CONFIRM:
+                if (_button.repeater == true) {
+                    if (_repeatInterval == 0) {
+                        _repeatInterval = (_button.easeInRepeater) ? _button.repeatInterval * 2 : _button.repeatInterval;
+                    }
+                    _button.actionRepeatInterval = _repeatInterval;
+                    event.repeater = true;
+                }
                 press();
+                if (_button.repeater == true) {
+                    _button.dispatch(new MouseEvent(MouseEvent.CLICK));
+                    if ( _repeatInterval > _button.repeatInterval) {
+                        _repeatInterval = Std.int(_repeatInterval - (_repeatInterval - _button.repeatInterval) / 2);
+                    }
+                }
             case _:    
         }
     }
@@ -671,6 +684,7 @@ class ButtonEvents extends haxe.ui.events.Events {
         switch (event.action) {
             case ActionType.PRESS | ActionType.CONFIRM:
                 release();
+                _repeatInterval = 0;
             case _:    
         }
     }


### PR DESCRIPTION
I had to do some change in the action manager. I now always remove the repeated action before adding it again.
This is is because when you're using the `easeInRepeater ` for the button, `actionRepeatInterval` should change between calls, but it seems there is no way to check the delay of an existing timer.