### PR TITLE
List item picker actions

### DIFF
--- a/haxe/ui/components/pickers/ItemPicker.hx
+++ b/haxe/ui/components/pickers/ItemPicker.hx
@@ -1,5 +1,6 @@
 package haxe.ui.components.pickers;
 
+import haxe.ui.actions.ActionType;
 import haxe.ui.components.Image;
 import haxe.ui.containers.Box;
 import haxe.ui.containers.HBox;
@@ -13,6 +14,7 @@ import haxe.ui.core.ItemRenderer;
 import haxe.ui.core.Screen;
 import haxe.ui.data.ArrayDataSource;
 import haxe.ui.data.DataSource;
+import haxe.ui.events.ActionEvent;
 import haxe.ui.events.MouseEvent;
 import haxe.ui.events.UIEvent;
 import haxe.ui.geom.Size;
@@ -144,6 +146,7 @@ class ItemPickerBuilder extends CompositeBuilder {
         var target = renderer.findComponent("itemPickerTrigger", Component);
         if (target != null) {
             picker.unregisterEvent(triggerEvent, onTrigger);
+            picker.unregisterEvent(ActionEvent.ACTION_START, onActionStart);
             picker.removeClass("item-picker-trigger");
             return target;
         }
@@ -192,7 +195,10 @@ class ItemPickerBuilder extends CompositeBuilder {
     private function registerTriggerEvents() {
         triggerTarget.addClass("item-picker-trigger");
         if (!triggerTarget.hasEvent(triggerEvent, onTrigger)) {
-            triggerTarget.registerEvent(triggerEvent, onTrigger);
+            triggerTarget.registerEvent(triggerEvent, onTrigger);  
+        }
+        if (!triggerTarget.hasEvent(ActionEvent.ACTION_START, onActionStart)) {
+            triggerTarget.registerEvent(ActionEvent.ACTION_START, onActionStart);
         }
     }
 
@@ -232,6 +238,14 @@ class ItemPickerBuilder extends CompositeBuilder {
             showPanel();
         } else {
             hidePanel();
+        }
+    }
+    private function onActionStart(event:ActionEvent) {
+        switch (event.action) {
+            case ActionType.CONFIRM | ActionType.PRESS:
+                event.cancel();
+                onTrigger(null);
+            case _:
         }
     }
 

--- a/haxe/ui/components/pickers/ListItemPicker.hx
+++ b/haxe/ui/components/pickers/ListItemPicker.hx
@@ -15,6 +15,10 @@ class ListItemPicker extends ItemPicker {
 }
 
 private class Builder extends ItemPickerBuilder {
+    private override function get_panelSelectionEvent():String {
+        return UIEvent.SUBMIT;
+    }
+
     private override function get_handlerClass():Class<ItemPickerHandler> {
         return Handler;
     }

--- a/haxe/ui/containers/ListView.hx
+++ b/haxe/ui/containers/ListView.hx
@@ -243,6 +243,7 @@ class ListViewEvents extends ScrollViewEvents {
 
             case SelectionMode.ONE_ITEM:
                 _listview.selectedIndex = renderer.itemIndex;
+                dispatch(new UIEvent(UIEvent.SUBMIT));
 
             case SelectionMode.ONE_ITEM_REPEATED:
                 _listview.selectedIndices = [renderer.itemIndex];
@@ -325,6 +326,8 @@ class ListViewEvents extends ScrollViewEvents {
                     _listview.selectedIndex = n;
                 }
                 event.repeater = true;
+            case ActionType.CONFIRM:
+                dispatch(new UIEvent(UIEvent.SUBMIT));
             case _:    
         }
     }


### PR DESCRIPTION
Added a dispatch SUBMIT event to the list views when there's a confirm action.
Added an ActionStart event to ItemPicker. I don't like it to much, feels it goes against the logic of the dynamic trigger event, but don't see how else to do it. (( In fact I feel maybe MouseEvents should also be action events, but that would too much of an undertaking :P) 
No CANCEL action yet. I wonder if I should add directly to the listview.  But don't feel it will be useful except in the case the listview is inside of an item picker
