### PR TITLE
Honour centerDialog

### DIFF
--- a/haxe/ui/backend/DialogBase.hx
+++ b/haxe/ui/backend/DialogBase.hx
@@ -183,7 +183,9 @@ class DialogBase extends Box implements Draggable {
             }
             Toolkit.callLater(function() {
                 handleVisibility(true);
-                centerDialogComponent(cast(this, Dialog));
+                if (centerDialog) {
+                    centerDialogComponent(cast(this, Dialog));
+                }
                 _forcedLeft = null;
                 _forcedTop = null;
                 if (autoCenterDialog) {


### PR DESCRIPTION
if centerDialog was false, it wouldn't honour it. ( would still in the x middlle of the screen)