### PR TITLE
Implemented a TreeViewEvent for when nodes get collapsed or expanded and fixed Null Object Reference Error.

### DIFF
--- a/haxe/ui/components/Image.hx
+++ b/haxe/ui/components/Image.hx
@@ -264,8 +264,10 @@ private class ResourceBehaviour extends DataBehaviour {
                         _component.invalidateComponent();
                         return;
                     }
+                    var subImage = null;
+                    
+                    if(_component != null && _component.findComponent(Image) != null) subImage = _component.findComponent(Image);
 
-                    var subImage = _component.findComponent(Image);
                     if (subImage != null) {
                         _component.removeComponent(subImage, false, false);
                     }

--- a/haxe/ui/containers/TreeView.hx
+++ b/haxe/ui/containers/TreeView.hx
@@ -246,7 +246,7 @@ class TreeViewEvent extends UIEvent{
     public static final NODE_COLLAPSE_EXPAND:EventType<TreeViewEvent> = EventType.name("nodecollapseexpand");
 
     public var expand:Bool = false;
-    public var node:TreeViewNode;
+    public var affected_node:TreeViewNode;
     public function new(type:EventType<TreeViewEvent>, expand:Bool = false, bubble:Null<Bool> = false, data:Dynamic = null){
         super(type, bubble, data);
         this.expand = expand;

--- a/haxe/ui/containers/TreeView.hx
+++ b/haxe/ui/containers/TreeView.hx
@@ -254,7 +254,7 @@ class TreeViewEvent extends UIEvent{
     public override function clone():TreeViewEvent {
         var c:TreeViewEvent = new TreeViewEvent(this.type);
         c.expand = this.expand;
-        c.affected_Node = this.affected_node;
+        c.affected_node = this.affected_node;
         c.type = this.type;
         c.bubble = this.bubble;
         c.target = this.target;

--- a/haxe/ui/containers/TreeView.hx
+++ b/haxe/ui/containers/TreeView.hx
@@ -251,8 +251,8 @@ class TreeViewEvent extends UIEvent{
         super(type, bubble, data);
         this.expand = expand;
     }
-    public override function clone():MenuEvent {
-        var c:MenuEvent = new MenuEvent(this.type);
+    public override function clone():TreeViewEvent {
+        var c:TreeViewEvent = new TreeViewEvent(this.type);
         c.expand = this.expand;
         c.affected_Node = this.affected_node;
         c.type = this.type;

--- a/haxe/ui/containers/TreeView.hx
+++ b/haxe/ui/containers/TreeView.hx
@@ -23,6 +23,8 @@ import haxe.ui.data.ArrayDataSource;
 import haxe.ui.data.DataSource;
 import haxe.ui.events.UIEvent;
 import haxe.ui.util.Variant;
+import haxe.ui.events.EventType;
+
 
 @:access(haxe.ui.containers.TreeViewNode)
 @:composite(TreeViewEvents, TreeViewBuilder)
@@ -34,6 +36,8 @@ class TreeView extends ScrollView implements IDataComponent {
     @:call(ClearNodes)                  public function clearNodes():Void;
     @:call(GetNodesInternal)            private function getNodesInternal():Array<Component>;
     
+    @:event(TreeViewEvent.NODE_COLLAPSE_EXPAND)        public var onCollapseExpand:TreeViewEvent->Void;
+
     private var _dataSource:DataSource<Dynamic> = null;
     public var dataSource(get, set):DataSource<Dynamic>;
     private function get_dataSource():DataSource<Dynamic> {
@@ -238,7 +242,16 @@ private class TreeViewBuilder extends ScrollViewBuilder {
     }
 }
 
+class TreeViewEvent extends UIEvent{
+    public static final NODE_COLLAPSE_EXPAND:EventType<TreeViewEvent> = EventType.name("nodecollapseexpand");
 
+    public var expand:Bool = false;
+    public var node:TreeViewNode;
+    public function new(type:EventType<TreeViewEvent>, expand:Bool = false, bubble:Null<Bool> = false, data:Dynamic = null){
+        super(type, bubble, data);
+        this.expand = expand;
+    }
+}
 
 
 /***************************************************************************************************

--- a/haxe/ui/containers/TreeView.hx
+++ b/haxe/ui/containers/TreeView.hx
@@ -251,6 +251,18 @@ class TreeViewEvent extends UIEvent{
         super(type, bubble, data);
         this.expand = expand;
     }
+    public override function clone():MenuEvent {
+        var c:MenuEvent = new MenuEvent(this.type);
+        c.expand = this.expand;
+        c.affected_Node = this.affected_node;
+        c.type = this.type;
+        c.bubble = this.bubble;
+        c.target = this.target;
+        c.data = this.data;
+        c.canceled = this.canceled;
+        postClone(c);
+        return c;
+    }
 }
 
 

--- a/haxe/ui/containers/TreeViewNode.hx
+++ b/haxe/ui/containers/TreeViewNode.hx
@@ -300,6 +300,7 @@ private class TreeViewNodeBuilder extends CompositeBuilder {
         updateIconClass();
         var event = new TreeViewEvent(TreeViewEvent.NODE_COLLAPSE_EXPAND);
         event.expand = _node.expanded;
+        event.affected_node = _node;
         treeview.dispatch(event);
     }
     

--- a/haxe/ui/containers/TreeViewNode.hx
+++ b/haxe/ui/containers/TreeViewNode.hx
@@ -298,7 +298,6 @@ private class TreeViewNodeBuilder extends CompositeBuilder {
         var treeview = _node.findAncestor(TreeView);
         _node.expanded = !_node.expanded;
         updateIconClass();
-        trace("expandCollapseClicked");
         var event = new TreeViewEvent(TreeViewEvent.NODE_COLLAPSE_EXPAND);
         event.expand = _node.expanded;
         treeview.dispatch(event);

--- a/haxe/ui/containers/TreeViewNode.hx
+++ b/haxe/ui/containers/TreeViewNode.hx
@@ -12,6 +12,7 @@ import haxe.ui.core.InteractiveComponent;
 import haxe.ui.core.ItemRenderer;
 import haxe.ui.events.MouseEvent;
 import haxe.ui.util.Variant;
+import haxe.ui.containers.TreeView.TreeViewEvent;
 
 #if (haxe_ver >= 4.2)
 import Std.isOfType;
@@ -294,8 +295,13 @@ private class TreeViewNodeBuilder extends CompositeBuilder {
     
     private function onExpandCollapseClicked(event:MouseEvent) {
         event.cancel();
+        var treeview = _node.findAncestor(TreeView);
         _node.expanded = !_node.expanded;
         updateIconClass();
+        trace("expandCollapseClicked");
+        var event = new TreeViewEvent(TreeViewEvent.NODE_COLLAPSE_EXPAND);
+        event.expand = _node.expanded;
+        treeview.dispatch(event);
     }
     
     public function updateIconClass() {


### PR DESCRIPTION
I implemented this because I needed it for an optimization in my own app to keep it performant, as adding a lot of nodes at once was very slow. 

I also fixed a Null Object Reference Error that happened every time new child nodes are added to a TreeViewNode.