### PR TITLE
Improved dialogs with parent components

### DIFF
--- a/haxe/ui/backend/DialogBase.hx
+++ b/haxe/ui/backend/DialogBase.hx
@@ -152,8 +152,6 @@ class DialogBase extends Box implements Draggable {
             if (dp != null) {
                 includeInLayout = false;
         		_overlay.includeInLayout = false;
-        		_overlay.screenTop = dp.screenTop;
-        		_overlay.screenLeft = dp.screenLeft;
         		_overlay.height = dp.height;
         		_overlay.width = dp.width;
         		dp.addComponent(_overlay);
@@ -188,7 +186,9 @@ class DialogBase extends Box implements Draggable {
                 }
                 _forcedLeft = null;
                 _forcedTop = null;
-                if (autoCenterDialog) {
+                if (dp != null) {
+                    dp.registerEvent(UIEvent.RESIZE, _onParentResized);
+                } else {
                     Screen.instance.registerEvent(UIEvent.RESIZE, _onScreenResized);
                 }
             });
@@ -196,9 +196,28 @@ class DialogBase extends Box implements Draggable {
     }
 
     private function _onScreenResized(_) {
+        if (!autoCenterDialog) {
+            return;
+        }
+
         _forcedLeft = null;
         _forcedTop = null;
         centerDialogComponent(cast this);
+    }
+
+    private function _onParentResized(_) {
+        if (_overlay != null) {
+            _overlay.width = dialogParent.width;
+            _overlay.height = dialogParent.height;
+        }
+
+        if (!autoCenterDialog) {
+            return;
+        }
+
+        _forcedLeft = null;
+        _forcedTop = null;
+        centerDialogComponent(cast this, false);
     }
     
     private var _buttonsCreated:Bool = false;
@@ -308,10 +327,18 @@ class DialogBase extends Box implements Draggable {
     private override function onDestroy() {
         super.onDestroy();
         if (_overlay != null) {
-            Screen.instance.removeComponent(_overlay);
+            if (dialogParent != null) {
+                dialogParent.removeComponent(_overlay);
+            } else {
+                Screen.instance.removeComponent(_overlay);
+            }
             _overlay = null;
         }
-        Screen.instance.unregisterEvent(UIEvent.RESIZE, _onScreenResized);
+        if (dialogParent != null) {
+            dialogParent.unregisterEvent(UIEvent.RESIZE, _onParentResized);
+        } else {
+            Screen.instance.unregisterEvent(UIEvent.RESIZE, _onScreenResized);
+        }
     }
     
     private function onContentResize(e) {


### PR DESCRIPTION
- Fixed modal overlay not being resized if it has a dialog parent
- Fixed dialog not being auto-centered if it has a parent
- Modal overlay is now properly removed if it has a dialog parent
- Removed setting `screenTop` and `screenLeft` (those variables don't have a setter function, so it doesn't do anything)

Before:

https://github.com/haxeui/haxeui-core/assets/85134252/588d8148-0afd-41bc-b627-2738ca610178

After:

https://github.com/haxeui/haxeui-core/assets/85134252/e36c200b-0e02-4e46-ba05-48bc897f0b09


