### PR TITLE
fix null object reference in ScrollView with no scroll bars

### DIFF
--- a/haxe/ui/containers/ScrollView.hx
+++ b/haxe/ui/containers/ScrollView.hx
@@ -1117,11 +1117,15 @@ class ScrollViewEvents extends haxe.ui.events.Events {
             scroll = _scrollview.findComponent(secondaryType, false);
         }
 
-        var currentScrollPolicy = scroll.id == 'scrollview-vscroll'
+        if (scroll != null) {
+            var currentScrollPolicy = scroll.id == 'scrollview-vscroll'
             ? _scrollview.verticalScrollPolicy
             : _scrollview.horizontalScrollPolicy;
 
-        if (scroll != null && currentScrollPolicy != ScrollPolicy.NEVER) {
+            if (currentScrollPolicy == ScrollPolicy.NEVER) {
+              return;
+            }
+
             if (_scrollview.autoHideScrolls == true && _fadeTimer == null) {
                 scroll.fadeIn();
             }


### PR DESCRIPTION
The changes I made to the ScrollPolicy rules in #590  is causing a null object reference when using the mouse wheel when there are no scrollbars.