### PR TITLE
add mouse button option for drag scrolling

### DIFF
--- a/haxe/ui/constants/MouseButton.hx
+++ b/haxe/ui/constants/MouseButton.hx
@@ -1,0 +1,7 @@
+package haxe.ui.constants;
+
+enum abstract MouseButton(String) from String to String {
+    var LEFT = 'left';
+    var MIDDLE = 'middle';
+    var RIGHT = 'right';
+}

--- a/haxe/ui/containers/ScrollView.hx
+++ b/haxe/ui/containers/ScrollView.hx
@@ -50,7 +50,7 @@ class ScrollView extends InteractiveComponent implements IScroller {
     @:clonable @:behaviour(VScrollPageSize)                         public var vscrollPageSize:Float;
     @:clonable @:behaviour(VScrollThumbSize)                        public var vscrollThumbSize:Null<Float>;
     @:clonable @:behaviour(ThumbSize)                               public var thumbSize:Null<Float>;
-    @:clonable @:behaviour(ScrollMouseButton)                       public var scrollMouseButton:MouseButton;
+    @:clonable @:behaviour(DefaultBehaviour, MouseButton.LEFT)      public var scrollMouseButton:MouseButton;
     @:clonable @:behaviour(ScrollModeBehaviour, ScrollMode.DRAG)    public var scrollMode:ScrollMode;
     @:clonable @:behaviour(ScrollPolicyBehaviour)                   public var scrollPolicy:ScrollPolicy;
     @:clonable @:behaviour(HScrollPolicyBehaviour)                  public var horizontalScrollPolicy:ScrollPolicy;
@@ -543,21 +543,6 @@ private class ThumbSize extends DataBehaviour {
     public override function validateData() { 
         _scrollview.hscrollThumbSize = _value;
         _scrollview.vscrollThumbSize = _value;
-    }
-}
-
-@:dox(hide) @:noCompletion
-@:access(haxe.ui.core.Component)
-private class ScrollMouseButton extends DataBehaviour {
-    private var _scrollview:ScrollView;
-
-    public function new(scrollview:ScrollView) {
-        super(scrollview);
-        _scrollview = scrollview;
-    }
-
-    public override function validateData() {
-        _scrollview.scrollMouseButton = _value;
     }
 }
 

--- a/haxe/ui/containers/ScrollView.hx
+++ b/haxe/ui/containers/ScrollView.hx
@@ -1,5 +1,6 @@
 package haxe.ui.containers;
 
+import haxe.ui.constants.MouseButton;
 import haxe.ui.actions.ActionType;
 import haxe.ui.behaviours.Behaviour;
 import haxe.ui.behaviours.DataBehaviour;
@@ -49,6 +50,7 @@ class ScrollView extends InteractiveComponent implements IScroller {
     @:clonable @:behaviour(VScrollPageSize)                         public var vscrollPageSize:Float;
     @:clonable @:behaviour(VScrollThumbSize)                        public var vscrollThumbSize:Null<Float>;
     @:clonable @:behaviour(ThumbSize)                               public var thumbSize:Null<Float>;
+    @:clonable @:behaviour(ScrollMouseButton)                       public var scrollMouseButton:MouseButton;
     @:clonable @:behaviour(ScrollModeBehaviour, ScrollMode.DRAG)    public var scrollMode:ScrollMode;
     @:clonable @:behaviour(ScrollPolicyBehaviour)                   public var scrollPolicy:ScrollPolicy;
     @:clonable @:behaviour(HScrollPolicyBehaviour)                  public var horizontalScrollPolicy:ScrollPolicy;
@@ -546,6 +548,21 @@ private class ThumbSize extends DataBehaviour {
 
 @:dox(hide) @:noCompletion
 @:access(haxe.ui.core.Component)
+private class ScrollMouseButton extends DataBehaviour {
+    private var _scrollview:ScrollView;
+
+    public function new(scrollview:ScrollView) {
+        super(scrollview);
+        _scrollview = scrollview;
+    }
+
+    public override function validateData() {
+        _scrollview.scrollMouseButton = _value;
+    }
+}
+
+@:dox(hide) @:noCompletion
+@:access(haxe.ui.core.Component)
 private class ScrollModeBehaviour extends DataBehaviour {
     public override function validateData() {
         _component.registerInternalEvents(true);
@@ -689,9 +706,13 @@ class ScrollViewEvents extends haxe.ui.events.Events {
         }
 
         if (_scrollview.scrollMode == ScrollMode.DRAG || _scrollview.scrollMode == ScrollMode.INERTIAL) {
-            registerEvent(MouseEvent.MOUSE_DOWN, onMouseDown);
-        } else if (hasEvent(MouseEvent.MOUSE_DOWN, onMouseDown)) {
-            unregisterEvent(MouseEvent.MOUSE_DOWN, onMouseDown);
+            registerEvent(MouseEvent.MIDDLE_MOUSE_DOWN, onMiddleMouseDown);
+            registerEvent(MouseEvent.MOUSE_DOWN, onLeftMouseDown);
+            registerEvent(MouseEvent.RIGHT_MOUSE_DOWN, onRightMouseDown);
+        } else if (hasEvent(MouseEvent.MOUSE_DOWN, onLeftMouseDown)) {
+            unregisterEvent(MouseEvent.MIDDLE_MOUSE_DOWN, onMiddleMouseDown);
+            unregisterEvent(MouseEvent.MOUSE_DOWN, onLeftMouseDown);
+            unregisterEvent(MouseEvent.RIGHT_MOUSE_DOWN, onRightMouseDown);
         }
 
         if (_scrollview.hasEvent(UIEvent.SHOWN) == false) {
@@ -736,7 +757,9 @@ class ScrollViewEvents extends haxe.ui.events.Events {
             vscroll.unregisterEvent(ScrollEvent.SCROLL, onVScrollScroll);
         }
 
-        unregisterEvent(MouseEvent.MOUSE_DOWN, onMouseDown);
+        unregisterEvent(MouseEvent.MIDDLE_MOUSE_DOWN, onMiddleMouseDown);
+        unregisterEvent(MouseEvent.RIGHT_MOUSE_DOWN, onRightMouseDown);
+        unregisterEvent(MouseEvent.MOUSE_DOWN, onLeftMouseDown);
         unregisterEvent(MouseEvent.MOUSE_WHEEL, onMouseWheel);
         unregisterEvent(UIEvent.SHOWN, onShown);
         unregisterEvent(UIEvent.COMPONENT_ADDED, onComponentAdded);
@@ -807,6 +830,27 @@ class ScrollViewEvents extends haxe.ui.events.Events {
     private function onVScrollScroll(event:UIEvent) {
         _target.dispatch(new ScrollEvent(ScrollEvent.SCROLL));
     }
+
+    @:access(haxe.ui.core.Component)
+    private function onLeftMouseDown(event:MouseEvent) {
+        if (_scrollview.scrollMouseButton == MouseButton.LEFT) {
+            onMouseDown(event);
+        }
+    }
+
+    @:access(haxe.ui.core.Component)
+    private function onMiddleMouseDown(event:MouseEvent) {
+        if (_scrollview.scrollMouseButton == MouseButton.MIDDLE) {
+            onMouseDown(event);
+        }
+    }
+
+    @:access(haxe.ui.core.Component)
+    private function onRightMouseDown(event:MouseEvent) {
+        if (_scrollview.scrollMouseButton == MouseButton.RIGHT) {
+            onMouseDown(event);
+        }
+    }
     
     private var _offset:Point;
     private static inline var INERTIAL_TIME_CONSTANT:Int = 325;
@@ -867,6 +911,8 @@ class ScrollViewEvents extends haxe.ui.events.Events {
         }
 
         Screen.instance.registerEvent(MouseEvent.MOUSE_MOVE, onMouseMove);
+        Screen.instance.registerEvent(MouseEvent.MIDDLE_MOUSE_UP, onMouseUp);
+        Screen.instance.registerEvent(MouseEvent.RIGHT_MOUSE_UP, onMouseUp);
         Screen.instance.registerEvent(MouseEvent.MOUSE_UP, onMouseUp);
     }
 
@@ -967,6 +1013,8 @@ class ScrollViewEvents extends haxe.ui.events.Events {
 
     private function onMouseUp(event:MouseEvent) {
         Screen.instance.unregisterEvent(MouseEvent.MOUSE_MOVE, onMouseMove);
+        Screen.instance.unregisterEvent(MouseEvent.MIDDLE_MOUSE_UP, onMouseUp);
+        Screen.instance.unregisterEvent(MouseEvent.RIGHT_MOUSE_UP, onMouseUp);
         Screen.instance.unregisterEvent(MouseEvent.MOUSE_UP, onMouseUp);
 
         if (_scrollview.scrollMode == ScrollMode.INERTIAL) {


### PR DESCRIPTION
Adds a property to ScrollView to allow choosing which mouse button can be used to drag scroll. I settled on `scrollMouseButton` after discussing it in Discord but if you like another option, please feel free to let me know and I'll change it.