### PR TITLE
stop closing menu when clicking on menu checkBoxes and optionBoxes

### DIFF
--- a/haxe/ui/containers/menus/Menu.hx
+++ b/haxe/ui/containers/menus/Menu.hx
@@ -166,6 +166,9 @@ class MenuEvents extends haxe.ui.events.Events {
 
     private function onItemClick(event:MouseEvent) {
         var item:MenuItem = cast(event.target, MenuItem);
+        if ((item is MenuCheckBox) || (item is MenuOptionBox)) {
+            return;
+        }
         if (!item.expandable) {
             var event = new MenuEvent(MenuEvent.MENU_SELECTED);
             event.menu = _menu;


### PR DESCRIPTION
Felt weird that the menu closes when clicking in a menu checkbox and menu option box.
The fix stops dispatching the MenuEvent.MENU_SELECTED in case of MenuCheckBoxes and menuOptionBoxes. I don't think it's a loss as CHANGE events work for them, but maybe it is?

```xml
<vbox width="100%" height="100%">
    <menubar width="100%">
        <menu text="Normal">
            <menuitem text="Item 1" shortcutText="Shortcut" />
            <menuitem text="Item 2 (disabled)" disabled="true" shortcutText="Ctrl+A" />
            <menu text="Sub Menu">
                <menuitem text="Item 1" />
                <menuitem text="Item 2" />
                <menuitem text="Item 3" />
                <menuseparator />
                <menucheckbox text="Item 4" selected="true" />
                <menucheckbox text="Item 5" />
                <menucheckbox text="Item 6" selected="true" />
                <menuseparator />
                <menuoptionbox text="Item 7" />
                <menuoptionbox text="Item 8" />
                <menuoptionbox text="Item 9" selected="true" />
                <menuseparator />
                <menuoptionbox text="Item 10" group="somegroup" />
                <menuoptionbox text="Item 11" group="somegroup" selected="true" />
                <menuoptionbox text="Item 12" group="somegroup" />
            </menu>
            <menuitem text="Item 3" shortcutText="Ctrl+B" />
            <menuitem text="Item 4" shortcutText="Ctrl+C" />
            <menuseparator />
            <menuitem text="Item 5" shortcutText="Ctrl+D" />
        </menu>
      </menubar>
    </vbox>
    ```