### PR TITLE
Add `isDragging` to `DragManager`

### DIFF
--- a/haxe/ui/dragdrop/DragManager.hx
+++ b/haxe/ui/dragdrop/DragManager.hx
@@ -24,6 +24,11 @@ class DragManager {
     // Instance
     //****************************************************************************************************
 
+    public var dragging(get, never):Bool;
+    inline function get_dragging():Bool {
+        return isDragging();
+    }
+
     private var _dragComponents:Map<Component, DragOptions>;
     private var _mouseTargetToDragTarget:Map<Component, Component>;
 
@@ -35,6 +40,13 @@ class DragManager {
     public function new() {
         _dragComponents = new Map<Component, DragOptions>();
         _mouseTargetToDragTarget = new Map<Component, Component>();
+    }
+
+    /**
+     * Returns true if a component is being dragged
+     */
+    public function isDragging():Bool {
+        return _currentComponent != null;
     }
 
     /**

--- a/haxe/ui/dragdrop/DragManager.hx
+++ b/haxe/ui/dragdrop/DragManager.hx
@@ -24,9 +24,12 @@ class DragManager {
     // Instance
     //****************************************************************************************************
 
-    public var dragging(get, never):Bool;
-    inline function get_dragging():Bool {
-        return isDragging();
+    /**
+     * Whether a component is currently being dragged
+     */
+    public var isDragging(get, never):Bool;
+    inline function get_isDragging():Bool {
+        return _currentComponent != null;
     }
 
     private var _dragComponents:Map<Component, DragOptions>;
@@ -40,13 +43,6 @@ class DragManager {
     public function new() {
         _dragComponents = new Map<Component, DragOptions>();
         _mouseTargetToDragTarget = new Map<Component, Component>();
-    }
-
-    /**
-     * Returns true if a component is being dragged
-     */
-    public function isDragging():Bool {
-        return _currentComponent != null;
     }
 
     /**

--- a/haxe/ui/dragdrop/DragManager.hx
+++ b/haxe/ui/dragdrop/DragManager.hx
@@ -28,7 +28,7 @@ class DragManager {
      * Whether a component is currently being dragged
      */
     public var isDragging(get, never):Bool;
-    inline function get_isDragging():Bool {
+    function get_isDragging():Bool {
         return _currentComponent != null;
     }
 


### PR DESCRIPTION
This pull requests adds a boolean helper to `DragManager` which returns whether a component is currently being dragged. Useful to stop external interactions with project related stuff etc.