### PR TITLE
Should look also in absolute paths for module resources etc

### DIFF
--- a/haxe/ui/macros/ModuleMacros.hx
+++ b/haxe/ui/macros/ModuleMacros.hx
@@ -289,7 +289,12 @@ class ModuleMacros {
         #if haxeui_macro_times
         var stopTimer = Context.timer("ModuleMacros.resolvePaths");
         #end
-
+        if (Path.isAbsolute(path)) {
+            var isDir = FileSystem.exists(path) && FileSystem.isDirectory(path);
+            if (isDir == true) {
+                paths.push(path);
+            }
+        }
         for (c in Context.getClassPath()) {
             if (c.length == 0) {
                 c = Sys.getCwd();


### PR DESCRIPTION
So that `<resource path='/media/[...]/assets' prefix="assets"/>` can work
I didn't put an if else because of paths  like `/haxe/ui/_module/styles` that are use by haxe ui core