### PR TITLE
Fix `RTTI.getClassProperties()` crashing when there is no `classInfo`

### DIFF
--- a/haxe/ui/util/RTTI.hx
+++ b/haxe/ui/util/RTTI.hx
@@ -137,6 +137,10 @@ class RTTI {
             return _allPropertiesCache.get(cacheKey);
         }
 
+        if (classInfo == null) {
+            return null;
+        }
+
         var entry = classInfo.get(className);
         var properties = null;
         if (entry != null) {


### PR DESCRIPTION
This crash happens on C++ when an item renderer gets added.