### PR TITLE
Fusion locales only when getting String

### DIFF
--- a/haxe/ui/locale/LocaleManager.hx
+++ b/haxe/ui/locale/LocaleManager.hx
@@ -271,7 +271,7 @@ class LocaleManager {
         var fusionedLocale:Map<String, String> = new Map();
         fusionedLocale = parentLocale.copy();
         for (k in locale.keys()) {
-            var v = map.get(k);
+            var v = locale.get(k);
             fusionedLocale.set(k, v);
         }
         return fusionedLocale;

--- a/haxe/ui/locale/LocaleManager.hx
+++ b/haxe/ui/locale/LocaleManager.hx
@@ -268,13 +268,13 @@ class LocaleManager {
         var parentLocale = _localeMap.get(parts[0]);
         var locale = _localeMap.get(parts[0]);
 
-        var fusionedLocale:Map<String, String> = new Map();
-        fusionedLocale = parentLocale.copy();
+        var mergedLocale:Map<String, String> = new Map();
+        mergedLocale = parentLocale.copy();
         for (k in locale.keys()) {
             var v = locale.get(k);
-            fusionedLocale.set(k, v);
+            mergedLocale.set(k, v);
         }
-        return fusionedLocale;
+        return mergedLocale;
     }
     
     public function hasString(id:String):Bool {

--- a/haxe/ui/locale/LocaleManager.hx
+++ b/haxe/ui/locale/LocaleManager.hx
@@ -256,33 +256,25 @@ class LocaleManager {
             }
             stringMap.set(k, v);
         }
-        
-        localeId = StringTools.replace(localeId, "-", "_");
-        var parts = localeId.split("_");
-        if (parts.length > 1) {
-            var parent = _localeMap.get(parts[0]);
-            if (parent != null) {
-                for (k in parent.keys()) {
-                    if (stringMap.exists(k) == false) {
-                        stringMap.set(k, parent.get(k));
-                    }
-                }
-            }
-        }
     }
     
     private function getStrings(localeId:String):Map<String, String> {
-        var strings = _localeMap.get(localeId);
-        if (strings != null) {
-            return strings;
-        }
-        
         localeId = StringTools.replace(localeId, "-", "_");
         var parts = localeId.split("_");
         if (!_localeMap.exists(parts[0])) {
             return _localeMap.get("en");
         }
-        return _localeMap.get(parts[0]);
+
+        var parentLocale = _localeMap.get(parts[0]);
+        var locale = _localeMap.get(parts[0]);
+
+        var fusionedLocale:Map<String, String> = new Map();
+        fusionedLocale = parentLocale.copy();
+        for (k in locale.keys()) {
+            var v = map.get(k);
+            fusionedLocale.set(k, v);
+        }
+        return fusionedLocale;
     }
     
     public function hasString(id:String):Bool {


### PR DESCRIPTION
I had added an en.properties but somehow when I was under en_US locale
I didn't see the "translated version" which is in lower case

![image](https://github.com/user-attachments/assets/e2ac604f-f4c8-4ab7-aae6-9b4d5f392b91)

The reason was that only once you parsed en_US  strings, it would add the "parent" strings. But my last parsed file one was as an "en" one and not an "en_US" one, so en strings were not added to en_US ones.

The solution I thought was to "fusion" en and en_US strings only in getStrings. Not only does it fix the bug but it saves space, as you don't have duplicate strings in en and en_US 
