### PR TITLE
Add quadratic, cubing, quartic eases

### DIFF
--- a/haxe/ui/styles/EasingFunction.hx
+++ b/haxe/ui/styles/EasingFunction.hx
@@ -25,4 +25,49 @@ enum abstract EasingFunction(String) from String {
      Specifies an animation with a slow start and end.
     **/
     var EASE_IN_OUT = "easeInOut";
+
+    /**
+     Specifies an animation with a quadratic slow start.
+    **/
+    var QUAD_IN = "quadIn";
+    
+    /**
+     Specifies an animation with a quadratic slow end.
+    **/
+    var QUAD_OUT = "quadOut";
+    
+    /**
+     Specifies an animation with a quadratic slow start and end.
+    **/
+    var QUAD_IN_OUT = "quadInOut";
+    
+    /**
+     Specifies an animation with a cubic slow start.
+    **/
+    var CUBIC_IN = "cubicIn";
+
+    /**
+     Specifies an animation with a cubic slow end.
+    **/    
+    var CUBIC_OUT = "cubicOut";
+    
+    /**
+     Specifies an animation with a cubic slow start and end.
+    **/
+    var CUBIC_IN_OUT = "cubicInOut";
+    
+    /**
+     Specifies an animation with a quartic slow start.
+    **/
+    var QUART_IN = "quartIn";
+    
+    /**
+     Specifies an animation with a quartic slow end.
+    **/
+    var QUART_OUT = "quartOut";
+ 
+    /**
+     Specifies an animation with a quartic slow start and end.
+    **/   
+    var QUART_IN_OUT = "quartInOut";
 }

--- a/haxe/ui/styles/animation/Animation.hx
+++ b/haxe/ui/styles/animation/Animation.hx
@@ -312,8 +312,14 @@ class Animation {
 
     private function _getReverseEasingFunction(easingFunction:EasingFunction):EasingFunction {
         return switch (easingFunction) {
-            case EasingFunction.EASE_OUT:   EasingFunction.EASE_IN;
-            case EasingFunction.EASE_IN:    EasingFunction.EASE_OUT;
+		  case EasingFunction.QUAD_OUT:   EasingFunction.QUAD_IN;
+		  case EasingFunction.QUAD_IN:    EasingFunction.QUAD_OUT;
+		  case EasingFunction.CUBIC_OUT:  EasingFunction.CUBIC_IN;
+		  case EasingFunction.CUBIC_IN:   EasingFunction.CUBIC_OUT;
+		  case EasingFunction.EASE_OUT:   EasingFunction.EASE_IN;
+		  case EasingFunction.EASE_IN:    EasingFunction.EASE_OUT;
+		  case EasingFunction.QUART_OUT:  EasingFunction.QUART_IN;
+		  case EasingFunction.QUART_IN:   EasingFunction.QUART_OUT;
             case _:                         easingFunction;
         }
     }

--- a/haxe/ui/styles/animation/util/Actuator.hx
+++ b/haxe/ui/styles/animation/util/Actuator.hx
@@ -389,28 +389,64 @@ private class Ease {
         return switch (easingFunction) {
             case EasingFunction.LINEAR:
                 linear;
-            case EasingFunction.EASE, EasingFunction.EASE_IN_OUT:
-                easeInOut;
-            case EasingFunction.EASE_IN:
-                easeIn;
-            case EasingFunction.EASE_OUT:
-                easeOut;
+		  case EasingFunction.QUAD_IN:
+		      quadIn;
+		  case EasingFunction.QUAD_OUT:
+			 quadOut;
+		  case EasingFunction.QUAD_IN_OUT:
+		      quadInOut;
+            case EasingFunction.EASE, EasingFunction.EASE_IN_OUT, EasingFunction.CUBIC_IN_OUT:
+                cubicInOut;
+            case EasingFunction.EASE_IN, EasingFunction.CUBIC_IN:
+                cubicIn;
+            case EasingFunction.EASE_OUT, EasingFunction.CUBIC_OUT:
+                cubicOut;
+		  case EasingFunction.QUART_IN:
+		      quartIn;
+		  case EasingFunction.QUART_OUT:
+		      quartOut;
+		  case EasingFunction.QUART_IN_OUT:
+		      quartInOut;
         }
     }
 
     public static function linear(k:Float):Float {
         return k;
     }
+    
+    public static function quadIn(k:Float):Float {
+	   return k * k;
+    }
+    
+    public static function quadOut(k:Float):Float {
+	   return -k * (k - 2);
+    }
+    
+    public static function quadInOut(k:Float):Float {
+	   return k <= .5 ? k * k * 2 : 1 - (--k) * k * 2;
+    }
 
-    public static function easeIn(k:Float):Float {
+    public static function cubicIn(k:Float):Float {
         return k * k * k;
     }
 
-    public static function easeOut(k:Float):Float {
+    public static function cubicOut(k:Float):Float {
         return --k * k * k + 1;
     }
 
-    public static function easeInOut(k:Float):Float {
+    public static function cubicInOut(k:Float):Float {
         return ((k /= 1 / 2) < 1) ? 0.5 * k * k * k : 0.5 * ((k -= 2) * k * k + 2);
+    }
+
+    public static function quartIn(k:Float):Float {
+        return k * k * k * k;
+    }
+
+    public static function quartOut(k:Float):Float {
+        return 1 - (k -= 1) * k * k * k;
+    }
+
+    public static function quartInOut(k:Float):Float {
+        return k <= .5 ? k * k * k * k * 8 : (1 - (k = k * 2 - 2) * k * k * k) / 2 + .5;
     }
 }


### PR DESCRIPTION
Add a few common easing functions, with a few questions regarding scope:

1. A quick search seems like CSS doesn't define a whole bunch of eases. Does that matter wrt what gets defined in haxeui?
2. Does "reverse easing function" need to be updated for every ease if it's a CSS thing?
3. Tunable complex eases like `bounce` maybe don't need to be implemented here? As in, externally defining a `Float->Float` easing function may be more flexible
4. If we define a bunch here, how many? Sine, quintic, exponential, back, circular, elastic...

Will update formatting, unless you have something quick for that