### PR TITLE
change to the Switch class to extend InteractiveComponent and disable focus on the Switch button

### DIFF
--- a/haxe/ui/components/Switch.hx
+++ b/haxe/ui/components/Switch.hx
@@ -16,7 +16,7 @@ import haxe.ui.util.Variant;
  * A switch component that can be used to toggle between two states.
  */
 @:composite(Builder, HorizontalLayout)
-class Switch extends Component implements IValueComponent implements ICompositeInteractiveComponent {
+class Switch extends InteractiveComponent implements IValueComponent implements ICompositeInteractiveComponent {
     //***********************************************************************************************************
     // Public API
     //***********************************************************************************************************
@@ -101,6 +101,7 @@ private class Builder extends CompositeBuilder {
     public override function create() {
         if (_button == null) {
             _button = new SwitchButtonSub();
+			_button.allowFocus = false;
             _button.onChange = function(e) {
                 _switch.selected = _button.selected;
                 _switch.dispatch(new UIEvent(UIEvent.CHANGE));


### PR DESCRIPTION
Change Switch to extend InteractiveComponent and allow ItemEvents and value prop to be linked in ItemRenderer components.