### PR TITLE
Email validator accepts domain both long and with unicode

### DIFF
--- a/haxe/ui/validators/EmailValidator.hx
+++ b/haxe/ui/validators/EmailValidator.hx
@@ -4,7 +4,7 @@ class EmailValidator extends PatternValidator {
     public function new() {
         super();
         invalidMessage = "Invalid email address";
-        pattern = ~/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/gm;
+        pattern = ~/^[^\-@\s:&!\/\\]+([\.-]?[^@\s:&!\/\\]+)*@[^\-@\s:&!\/\\\.]+([\.-]?[^@\s:&!\/\\\.]+)*(\.[^\-@\s:&!\/\\\.]{2,})+$/gm;
         //pattern = new EReg("^\\w+([\\.-]?\\w+)*@\\w+([\\.-]?\\w+)*(\\.\\w{2,3})+$", "gm");
    }
 }


### PR DESCRIPTION
Bit convoluted as unicode regex are supported only on certain targets but should hit sweet spot between correctness and complexity.

Resolves #516