### PR TITLE
Fix compiling errors with haxeui-flixel

### DIFF
--- a/haxe/ui/containers/Panel.hx
+++ b/haxe/ui/containers/Panel.hx
@@ -49,7 +49,7 @@ class Panel extends VBox {
         return super.set_percentHeight(value);
     }
 
-    #if ((haxeui_openfl || haxeui_nme) && !haxeui_flixel)
+    #if (haxeui_openfl || haxeui_nme || haxeui_flixel)
 
     public override function set_height(value:Float):Float {
         contentContainer.percentHeight = 100;


### PR DESCRIPTION
A recent commit was made that makes set_height in Panel use Null<Float>, however this causes a compiler error when using the Flixel backend of HaxeUI, since FlxObjects do not take in a Null<Float> for their height