### PR TITLE
TableView removeColumn using id

### DIFF
--- a/haxe/ui/containers/TableView.hx
+++ b/haxe/ui/containers/TableView.hx
@@ -1002,10 +1002,11 @@ private class RemoveColumn extends Behaviour {
             return null;
         }
         for (c in header.findComponents(Column)) {
-            if (c.id == null) {
+            final id = c.id;
+            if (id == null) {
                 continue;
             }
-            if (c.text == param) {
+            if (id == param) {
                 header.removeComponent(c);
                 break;
             }


### PR DESCRIPTION
removeColumn did not work because it used the text and not the id property of the column.