### PR TITLE
Add `forceStep` property to NumberStepper

### DIFF
--- a/haxe/ui/components/NumberStepper.hx
+++ b/haxe/ui/components/NumberStepper.hx
@@ -53,7 +53,7 @@ class NumberStepper extends InteractiveComponent implements ICompositeInteractiv
     /**
      * If true, values that differ from the specified `step` will be marked as invalid.
      */
-    @:clonable @:behaviour(DefaultBehaviour, false)                      public var forceStep:Bool;
+    @:clonable @:behaviour(DefaultBehaviour, false)                     public var forceStep:Bool;
 
     /**
      * The highest value this stepper can get to, even when set through code.

--- a/haxe/ui/components/NumberStepper.hx
+++ b/haxe/ui/components/NumberStepper.hx
@@ -51,6 +51,11 @@ class NumberStepper extends InteractiveComponent implements ICompositeInteractiv
     @:clonable @:behaviour(DefaultBehaviour, null)                      public var step:Null<Float>;
 
     /**
+     * If true, values that differ from the specified `step` will be marked as invalid.
+     */
+    @:clonable @:behaviour(DefaultBehaviour, true)                      public var forceStep:Bool;
+
+    /**
      * The highest value this stepper can get to, even when set through code.
      */
     @:clonable @:behaviour(DefaultBehaviour, null)                      public var max:Null<Float>;
@@ -308,7 +313,7 @@ private class Events extends haxe.ui.events.Events {
         }
         var parsedValue = Std.parseFloat(value.text);
         parsedValue = MathUtil.clamp(parsedValue, _stepper.min, _stepper.max);
-        if (_stepper.step != null && parsedValue % _stepper.step != 0) {
+        if (_stepper.step != null && _stepper.forceStep && parsedValue % _stepper.step != 0) {
             parsedValue = MathUtil.roundToNearest(parsedValue, _stepper.step);
         }
 
@@ -491,7 +496,7 @@ private class ValueHelper {
             valid = false;
         }
 
-        if (step != null && MathUtil.fmodulo(parsedValue, step) != 0) {
+        if (step != null && stepper.forceStep && MathUtil.fmodulo(parsedValue, step) != 0) {
             valid = false;
             parsedValue = MathUtil.roundToNearest(parsedValue, step);
         }
@@ -523,7 +528,9 @@ private class ValueHelper {
             }
         } else {
             newValue += step;
-            newValue = MathUtil.roundToNearest(newValue, step);
+            if (stepper.forceStep) {
+                newValue = MathUtil.roundToNearest(newValue, step);
+            }
         }
         
         if (max != null && newValue > max) {
@@ -549,7 +556,9 @@ private class ValueHelper {
             }
         } else {
             newValue -= step;
-            newValue = MathUtil.roundToNearest(newValue, step);
+            if (stepper.forceStep) {
+                newValue = MathUtil.roundToNearest(newValue, step);
+            }
         }
         
         if (min != null && newValue < min) {

--- a/haxe/ui/components/NumberStepper.hx
+++ b/haxe/ui/components/NumberStepper.hx
@@ -53,7 +53,7 @@ class NumberStepper extends InteractiveComponent implements ICompositeInteractiv
     /**
      * If true, values that differ from the specified `step` will be marked as invalid.
      */
-    @:clonable @:behaviour(DefaultBehaviour, true)                      public var forceStep:Bool;
+    @:clonable @:behaviour(DefaultBehaviour, false)                      public var forceStep:Bool;
 
     /**
      * The highest value this stepper can get to, even when set through code.

--- a/haxe/ui/containers/properties/Property.hx
+++ b/haxe/ui/containers/properties/Property.hx
@@ -17,6 +17,7 @@ class Property extends HBox implements IDataComponent {
     @:clonable @:behaviour(DefaultBehaviour, null)      public var min:Null<Float>;
     @:clonable @:behaviour(DefaultBehaviour, null)      public var max:Null<Float>;
     @:clonable @:behaviour(DefaultBehaviour, null)      public var step:Null<Float>;
+    @:clonable @:behaviour(DefaultBehaviour, null)      public var forceStep:Null<Bool>;
     @:clonable @:behaviour(DefaultBehaviour, null)      public var precision:Null<Int>;
     @:behaviour(DataSourceBehaviour)                    public var dataSource:DataSource<Dynamic>;
 }

--- a/haxe/ui/containers/properties/PropertyEditor.hx
+++ b/haxe/ui/containers/properties/PropertyEditor.hx
@@ -169,6 +169,9 @@ class PropertyEditorNumber extends PropertyEditor {
         if (property.step != null) {
             numberStepper.step = property.step;
         }
+        if (property.forceStep != null) {
+            numberStepper.forceStep = property.forceStep;
+        }
         if (property.precision != null) {
             numberStepper.precision = property.precision;
         }

--- a/haxe/ui/containers/properties/PropertyGroup_OLD.hx
+++ b/haxe/ui/containers/properties/PropertyGroup_OLD.hx
@@ -338,6 +338,9 @@ private class Builder extends CompositeBuilder {
                     if (property.step != null) {
                         stepper.step = property.step;
                     }
+                    if (property.forceStep != null) {
+                        stepper.forceStep = property.forceStep;
+                    }
                     if (property.precision != null) {
                         stepper.precision = property.precision;
                     }

--- a/haxe/ui/containers/properties/Property_OLD.hx
+++ b/haxe/ui/containers/properties/Property_OLD.hx
@@ -18,6 +18,7 @@ class Property_OLD extends HBox implements IDataComponent {
     @:behaviour(DataSourceBehaviour)                    public var dataSource:DataSource<Dynamic>;
     @:clonable @:behaviour(PropertyValueBehaviour)      public var value:Dynamic;
     @:clonable @:behaviour(DefaultBehaviour)            public var step:Null<Float>;
+    @:clonable @:behaviour(DefaultBehaviour)            public var forceStep:Null<Bool>;
     @:clonable @:behaviour(DefaultBehaviour)            public var min:Null<Float>;
     @:clonable @:behaviour(DefaultBehaviour)            public var max:Null<Float>;
     @:clonable @:behaviour(DefaultBehaviour)            public var precision:Null<Int>;


### PR DESCRIPTION
This new property lets you dictate whether or not the value on number steppers needs to follow the step to be marked as valid. This allows you to set a custom step for convenience while still accepting values that differ from it (for example, I want a sprite scale property with a step of 0.05, but I also want any value to work even if it isn't a multiple of 0.05).

It is set to true by default for backwards compatibility. I also implemented it for the number properties in property groups, as the step can be changed there as well (and it's where I was using number steppers to begin with).