### PR TITLE
Allow resource paths relative to the module.xml's containing dir

### DIFF
--- a/haxe/ui/macros/ModuleMacros.hx
+++ b/haxe/ui/macros/ModuleMacros.hx
@@ -75,6 +75,7 @@ class ModuleMacros {
                 var exclusions = ModuleResourceEntry.globalExclusions.concat(r.exclusions);
 
                 if (r.path != null) {
+                    r.path = StringTools.replace(r.path, "<module>", m.rootPath);
                     if (r.prefix == null) {
                         r.prefix = r.path;
                     }

--- a/haxe/ui/macros/ModuleMacros.hx
+++ b/haxe/ui/macros/ModuleMacros.hx
@@ -75,7 +75,7 @@ class ModuleMacros {
                 var exclusions = ModuleResourceEntry.globalExclusions.concat(r.exclusions);
 
                 if (r.path != null) {
-                    r.path = StringTools.replace(r.path, "<module>", m.rootPath);
+                    r.path = StringTools.replace(r.path, "${module}", m.rootPath);
                     if (r.prefix == null) {
                         r.prefix = r.path;
                     }


### PR DESCRIPTION
Usage example:

```
<module>
    <resources>
        <resource path="${module}/assets/fonts" prefix="fonts" />
        <resource path="${module}/assets/images" prefix="images" />
    </resources>
</module>
```