### PR TITLE
Fix stale locale binding surviving reassignment to a literal/different value

### DIFF
--- a/haxe/ui/locale/LocaleManager.hx
+++ b/haxe/ui/locale/LocaleManager.hx
@@ -84,6 +84,24 @@ class LocaleManager {
     public function unregisterComponent(component:Component) {
         _registeredComponents.remove(component);
     }
+
+    public function unregisterProperty(component:Component, prop:String) {
+        var propMap = _registeredComponents.get(component);
+        if (propMap == null) {
+            return;
+        }
+        propMap.remove(prop);
+    }
+
+    /*
+        Guards the Reflect.setProperty calls in refreshFor below: those re-invoke the same
+        generated property setter that calls unregisterProperty above for any non-{{}} value, since
+        by the time refreshFor resolves a binding to a plain string, that string no longer contains
+        "{{"/"}}" either. Without this guard, applying a freshly-registered binding for the first
+        time would immediately unregister the very entry refreshFor just used, silently turning every
+        binding into a one-shot that never updates again on a later locale change.
+    */
+    public var isRefreshing(default, null):Bool = false;
     
     public function findBindingExpr(component:Component, prop:String):String {
         var propMap = _registeredComponents.get(component);
@@ -137,6 +155,7 @@ class LocaleManager {
         }
         
         
+        isRefreshing = true;
         for (prop in propMap.keys()) {
             var entry = propMap.get(prop);
             if (entry.callback != null) {
@@ -147,6 +166,7 @@ class LocaleManager {
                 Reflect.setProperty(component, prop, value);
             }
         }
+        isRefreshing = false;
     }
     
     public function refreshAll() {

--- a/haxe/ui/macros/Macros.hx
+++ b/haxe/ui/macros/Macros.hx
@@ -676,7 +676,10 @@ class Macros {
                                         haxe.ui.locale.LocaleManager.instance.registerComponent(cast this, $v{f.name}, value);
                                         return value;
                                     }
-                                case _:    
+                                case _:
+                            }
+                            if (haxe.ui.locale.LocaleManager.instance.isRefreshing == false) {
+                                haxe.ui.locale.LocaleManager.instance.unregisterProperty(cast this, $v{f.name});
                             }
                             if (behaviours == null) {
                                 behaviours = new haxe.ui.behaviours.Behaviours(cast this);


### PR DESCRIPTION
Demo: http://haxeui.org/builder/?a0a12ea2
Press "Set fixed", then press "Change locale"

A component property once bound to a {{key}} locale binding kept reverting to that key's value on later locale changes even after being reassigned to a literal (or a different key), since the generated isString setter only ever registered a binding, never unregistered one for a plain-value reassignment.

Add LocaleManager.unregisterProperty(component, prop) for clearing a single property's binding (unlike the existing all-or-nothing unregisterComponent), and call it from the generated setter whenever the new value isn't itself a binding. Guard it with a new isRefreshing flag set around refreshFor's own Reflect.setProperty calls, since those re-invoke the same setter with an already-resolved (non-{{}}) value - without the guard a freshly registered binding would immediately unregister itself the first time it was applied.