### PR TITLE
TextArea: apply an auto height to text the application set, and honou…

### DIFF
--- a/haxe/ui/components/TextArea.hx
+++ b/haxe/ui/components/TextArea.hx
@@ -116,9 +116,37 @@ class TextArea extends InteractiveComponent implements IFocusable implements ICo
         super.validateComponentInternal(nextFrame);
 
         if (scrollInvalid || layoutInvalid || dataInvalid) {
+            applyAutoHeight();
             if (_compositeBuilder != null) {
                 cast(_compositeBuilder, TextAreaBuilder).checkScrolls(); // TODO: would be nice to not have this
             }
+        }
+    }
+
+    /**
+        Size an `auto` height text area to the text it holds, up to `max-height`.
+
+        Also done as the user types (see the change handler below), but this is
+        what makes it true of text the application SET: the height comes from a
+        measurement, and the measurement is only real once the text has been laid
+        out - which is here, after the validation that lays it out, rather than at
+        the moment the text was assigned.
+
+        Beyond `max-height` the height stops and the rest of the text scrolls,
+        which is the whole point of having a maximum: without the clamp the box
+        simply stayed at whatever height it had already reached.
+    **/
+    private function applyAutoHeight() {
+        if (style == null || style.autoHeight != true || !hasTextInput()) {
+            return;
+        }
+        var newHeight = getTextInput().textHeight + 8; // TODO: magic number, as above
+        var maxHeight = style.maxHeight;
+        if (maxHeight != null && newHeight > maxHeight) {
+            newHeight = maxHeight;
+        }
+        if (newHeight > 0 && this.height != newHeight) {
+            this.height = newHeight;
         }
     }
 }
@@ -466,13 +494,7 @@ private class Events extends haxe.ui.events.Events {
                     }
                     _textarea.text = text;
                     _textarea.dispatch(new UIEvent(UIEvent.CHANGE));
-                    if (_textarea.style.autoHeight == true) {
-                        var maxHeight = _textarea.style.maxHeight;
-                        var newHeight = _textarea.getTextInput().textHeight + 8; // TODO: where does this magic number come from, seems to work across all backends - doesnt seem to be padding
-                        if (maxHeight == null || newHeight < maxHeight) {
-                            _textarea.height = newHeight;
-                        }
-                    }
+                    @:privateAccess _textarea.applyAutoHeight();
 
                     cast(_textarea._compositeBuilder, TextAreaBuilder).checkScrolls();
                 }
@@ -558,16 +580,7 @@ private class Events extends haxe.ui.events.Events {
     }
 
     private function onScrollChange(event:UIEvent) {
-        if (_textarea.style.autoHeight == true) {
-            var maxHeight = _textarea.style.maxHeight;
-            var newHeight = _textarea.getTextInput().textHeight + 8; // TODO: where does this magic number come from, seems to work across all backends - doesnt seem to be padding
-            if (maxHeight == null || newHeight < maxHeight) {
-                _textarea.height = newHeight;
-            }
-            if (maxHeight != null && newHeight > maxHeight) {
-                _textarea.height = maxHeight;
-            }
-        }
+        @:privateAccess _textarea.applyAutoHeight();
         var hscroll:HorizontalScroll = _textarea.findComponent(HorizontalScroll, false);
         if (hscroll != null) {
             _textarea.getTextInput().hscrollPos = hscroll.pos;

--- a/haxe/ui/containers/HorizontalSplitter.hx
+++ b/haxe/ui/containers/HorizontalSplitter.hx
@@ -26,25 +26,46 @@ private class HorizontalSplitterEvents extends SplitterEvents {
     }
 
     private override function handleResize(prev:Component, next:Component, event:MouseEvent) {
-        var screenX = _splitter.screenLeft;
-        var delta = event.screenX - screenX - _currentOffset.x;
-        var ucx = _splitter.layout.usableWidth;
-        
-        var prevCX = delta;
-        var nextCX = ucx - delta;
-        
-        var prevMinWidth:Float = 0;
-        var nextMinWidth:Float = 0;
-        
-        var prevMaxWidth:Null<Float> = null;
-        var nextMaxWidth:Null<Float> = null;
-        
+        if (prev == null || next == null) {
+            return;
+        }
+
+        // What the two panes share between them. NOT `layout.usableWidth`,
+        // which is only what is left for the PERCENT children — see
+        // SplitterEvents.usableAfter.
+        var ucx = _dragTotalCX;
+
+        // Measured from the mouse-down, so no component screen coordinate (real
+        // pixels) is ever subtracted from a mouse coordinate (layout units).
+        var prevCX = _dragPrevCX + (event.screenX - _dragFromX);
+        var nextCX = ucx - prevCX;
+
+        // A pane's own limits, which these four have always been named for and
+        // never read. Without them a splitter will happily shrink a pane past
+        // the width its style says it may have: Component clamps the width it
+        // is given, but the splitter goes on believing the pair still adds up,
+        // so the surplus is pushed out of the far side of the splitter and the
+        // last pane leaves the window.
+        var prevMinWidth:Float = minWidthOf(prev);
+        var nextMinWidth:Float = minWidthOf(next);
+
+        var prevMaxWidth:Null<Float> = maxWidthOf(prev);
+        var nextMaxWidth:Null<Float> = maxWidthOf(next);
+
+        // Two minimums that cannot both be met (a splitter narrower than the
+        // pair needs) would clamp against each other forever; share it out.
+        if (prevMinWidth + nextMinWidth > ucx) {
+            var scale = (prevMinWidth + nextMinWidth > 0) ? ucx / (prevMinWidth + nextMinWidth) : 0;
+            prevMinWidth *= scale;
+            nextMinWidth *= scale;
+        }
+
         // limit to min sizes
-        if (prevCX <= prevMinWidth) {
+        if (prevCX < prevMinWidth) {
             prevCX = prevMinWidth;
             nextCX = ucx - prevMinWidth;
         }
-        if (nextCX <= nextMinWidth) {
+        if (nextCX < nextMinWidth) {
             prevCX = ucx - nextMinWidth;
             nextCX = nextMinWidth;
         }
@@ -58,7 +79,7 @@ private class HorizontalSplitterEvents extends SplitterEvents {
             prevCX = ucx - nextMaxWidth;
             nextCX = nextMaxWidth;
         }
-        
+
         // bit of a hack to make things look a little nicer
         if (prevCX <= 0) {
             @:privateAccess prev.handleVisibility(false);
@@ -70,18 +91,35 @@ private class HorizontalSplitterEvents extends SplitterEvents {
         } else {
             @:privateAccess next.handleVisibility(true);
         }
-        
-        // assign new sizes
+
+        // assign new sizes. A percentage is worked out against the width it
+        // will actually resolve against once the FIXED pane of the pair has
+        // taken its new size, which is not the width it resolves against now.
+        var after = usableAfter(_splitter.layout.usableWidth, prev, next, prevCX, nextCX);
         if (prev.percentWidth != null) {
-            prev.percentWidth = (prevCX / ucx) * 100;
+            prev.percentWidth = (after > 0) ? (prevCX / after) * 100 : 0;
         } else {
             prev.width = prevCX;
         }
         if (next.percentWidth != null) {
-            next.percentWidth = (nextCX / ucx) * 100;
+            next.percentWidth = (after > 0) ? (nextCX / after) * 100 : 0;
         } else {
             next.width = nextCX;
         }
+    }
+
+    private static function minWidthOf(c:Component):Float {
+        if (c == null || c.style == null || c.style.minWidth == null) {
+            return 0;
+        }
+        return c.style.minWidth;
+    }
+
+    private static function maxWidthOf(c:Component):Null<Float> {
+        if (c == null || c.style == null) {
+            return null;
+        }
+        return c.style.maxWidth;
     }
 }
 

--- a/haxe/ui/containers/Splitter.hx
+++ b/haxe/ui/containers/Splitter.hx
@@ -48,11 +48,73 @@ class SplitterEvents extends haxe.ui.events.Events {
 
     private var _currentGripper:SizerGripper = null;
     private var _currentOffset:Point = null;
+
+    // The drag is measured DIFFERENTIALLY, from where the mouse went down and
+    // the sizes the two panes had at that moment, rather than from the
+    // splitter's own screen position. Two reasons, and the second is a bug:
+    //
+    //   A component's `screenLeft` comes from `screenBounds`, which multiplies
+    //   every ancestor offset by `Toolkit.scale`, so it is in REAL pixels. A
+    //   MouseEvent's `screenX` has already been divided by `Toolkit.scaleX` by
+    //   the backend, so it is in LAYOUT units. Subtracting one from the other
+    //   is only harmless at scale 1; at 1.5 or 2 the gripper runs away from the
+    //   cursor. Comparing two mouse positions mixes no units and needs no
+    //   knowledge of the scale at all.
+    //
+    //   It also makes the arithmetic independent of WHERE the pair sits: the
+    //   old form measured from the splitter's left edge, which is only the
+    //   previous pane's left edge for the FIRST pair, so every later gripper in
+    //   a multi-pane splitter was handed the earlier panes' widths as well.
+    private var _dragFromX:Float = 0;
+    private var _dragFromY:Float = 0;
+    private var _dragPrevCX:Float = 0;
+    private var _dragPrevCY:Float = 0;
+    private var _dragTotalCX:Float = 0;
+    private var _dragTotalCY:Float = 0;
+
     private function onGripperMouseDown(event:MouseEvent) {
         _currentGripper = cast(event.target, SizerGripper);
         _currentOffset = new Point(event.screenX - _currentGripper.screenLeft, event.screenY - _currentGripper.screenTop);
+
+        _dragFromX = event.screenX;
+        _dragFromY = event.screenY;
+        var index = _splitter.getComponentIndex(_currentGripper);
+        var prev = _splitter.getComponentAt(index - 1);
+        var next = _splitter.getComponentAt(index + 1);
+        _dragPrevCX = (prev != null) ? prev.width : 0;
+        _dragPrevCY = (prev != null) ? prev.height : 0;
+        _dragTotalCX = _dragPrevCX + ((next != null) ? next.width : 0);
+        _dragTotalCY = _dragPrevCY + ((next != null) ? next.height : 0);
+
         Screen.instance.registerEvent(MouseEvent.MOUSE_MOVE, onScreenMouseMove);
         Screen.instance.registerEvent(MouseEvent.MOUSE_UP, onScreenMouseUp);
+    }
+
+    /**
+     * The width a percent-sized pane's percentage will resolve against once the
+     * drag's new sizes are in.
+     *
+     * `layout.usableWidth` is what is left for the PERCENT children: it already
+     * has the fixed-width children and the grippers taken out of it. So it is
+     * not the amount the two panes share (that is `prev.width + next.width`),
+     * and it is not a fixed denominator either — resizing a fixed pane moves it.
+     * Both of those were assumed, which is why a splitter pairing a percent pane
+     * with a fixed one sized the percent pane against a number that changed
+     * underneath it: the pane landed somewhere other than the cursor, and the
+     * far half of the travel collapsed the fixed pane to nothing.
+     */
+    private function usableAfter(usableNow:Float, prev:Component, next:Component, prevCX:Float, nextCX:Float):Float {
+        var after = usableNow;
+        if (prev != null && prev.percentWidth == null) after += prev.width - prevCX;
+        if (next != null && next.percentWidth == null) after += next.width - nextCX;
+        return after;
+    }
+
+    private function usableAfterV(usableNow:Float, prev:Component, next:Component, prevCY:Float, nextCY:Float):Float {
+        var after = usableNow;
+        if (prev != null && prev.percentHeight == null) after += prev.height - prevCY;
+        if (next != null && next.percentHeight == null) after += next.height - nextCY;
+        return after;
     }
 
     private function onScreenMouseMove(event:MouseEvent) {

--- a/haxe/ui/containers/VerticalSplitter.hx
+++ b/haxe/ui/containers/VerticalSplitter.hx
@@ -26,25 +26,35 @@ private class VerticalSplitterEvents extends SplitterEvents {
     }
 
     private override function handleResize(prev:Component, next:Component, event:MouseEvent) {
-        var screenY = _splitter.screenTop;
-        var delta = event.screenY - screenY - _currentOffset.y;
-        var ucy = _splitter.layout.usableHeight;
-        
-        var prevCY = delta;
-        var nextCY = ucy - delta;
-        
-        var prevMinHeight:Float = 0;
-        var nextMinHeight:Float = 0;
-        
-        var prevMaxHeight:Null<Float> = null;
-        var nextMaxHeight:Null<Float> = null;
-        
+        if (prev == null || next == null) {
+            return;
+        }
+
+        // The horizontal twin carries the account of both fixes.
+        var ucy = _dragTotalCY;
+        var prevCY = _dragPrevCY + (event.screenY - _dragFromY);
+        var nextCY = ucy - prevCY;
+
+        // See the horizontal twin: these four have always been named for the
+        // panes' own limits and never read them.
+        var prevMinHeight:Float = minHeightOf(prev);
+        var nextMinHeight:Float = minHeightOf(next);
+
+        var prevMaxHeight:Null<Float> = maxHeightOf(prev);
+        var nextMaxHeight:Null<Float> = maxHeightOf(next);
+
+        if (prevMinHeight + nextMinHeight > ucy) {
+            var scale = (prevMinHeight + nextMinHeight > 0) ? ucy / (prevMinHeight + nextMinHeight) : 0;
+            prevMinHeight *= scale;
+            nextMinHeight *= scale;
+        }
+
         // limit to min sizes
-        if (prevCY <= prevMinHeight) {
+        if (prevCY < prevMinHeight) {
             prevCY = prevMinHeight;
             nextCY = ucy - prevMinHeight;
         }
-        if (nextCY <= nextMinHeight) {
+        if (nextCY < nextMinHeight) {
             prevCY = ucy - nextMinHeight;
             nextCY = nextMinHeight;
         }
@@ -58,7 +68,7 @@ private class VerticalSplitterEvents extends SplitterEvents {
             prevCY = ucy - nextMaxHeight;
             nextCY = nextMaxHeight;
         }
-        
+
         // bit of a hack to make things look a little nicer
         if (prevCY <= 0) {
             @:privateAccess prev.handleVisibility(false);
@@ -70,41 +80,33 @@ private class VerticalSplitterEvents extends SplitterEvents {
         } else {
             @:privateAccess next.handleVisibility(true);
         }
-        
-        // assign new sizes
-        if (prev.percentHeight != null) {
-            prev.percentHeight = (prevCY / ucy) * 100;
-        } else {
-            prev.height = prevCY;
-        }
-        if (next.percentHeight != null) {
-            next.percentHeight = (nextCY / ucy) * 100;
-        } else {
-            next.height = nextCY;
-        }
-        
-        /*
-        var delta = event.screenY - _currentOffset.y;
-        var prevCY = prev.height += delta;
-        var nextCY = next.height -= delta;
-        var ucy = _splitter.layout.usableHeight;
-        
-        if (prevCY <= 0 || nextCY <= 0) {
-            return;
-        }
-        
-        if (prev.percentHeight != null) {
-            prev.percentHeight = (prevCY / ucy) * 100;
-        } else {
-            prev.height = prevCY;
-        }
 
+        // assign new sizes
+        var after = usableAfterV(_splitter.layout.usableHeight, prev, next, prevCY, nextCY);
+        if (prev.percentHeight != null) {
+            prev.percentHeight = (after > 0) ? (prevCY / after) * 100 : 0;
+        } else {
+            prev.height = prevCY;
+        }
         if (next.percentHeight != null) {
-            next.percentHeight = (nextCY / ucy) * 100;
+            next.percentHeight = (after > 0) ? (nextCY / after) * 100 : 0;
         } else {
             next.height = nextCY;
         }
-        */
+    }
+
+    private static function minHeightOf(c:Component):Float {
+        if (c == null || c.style == null || c.style.minHeight == null) {
+            return 0;
+        }
+        return c.style.minHeight;
+    }
+
+    private static function maxHeightOf(c:Component):Null<Float> {
+        if (c == null || c.style == null) {
+            return null;
+        }
+        return c.style.maxHeight;
     }
 }
 

--- a/haxe/ui/tooltips/ToolTipManager.hx
+++ b/haxe/ui/tooltips/ToolTipManager.hx
@@ -263,11 +263,24 @@ class ToolTipManager {
             return;
         }
         
+        var options = _toolTipOptions.get(component);
+        if (options == null) {
+            // Unregistered while the delay timer was running, so there is
+            // nothing left to show. Not a rare race: the hover starts the
+            // timer, and anything that rebuilds the part of the UI under the
+            // cursor before it fires - a selection change that replaces a
+            // property panel, a list that repopulates - unregisters the
+            // component the timer is still holding. Reading tipData off the
+            // missing options then takes the application down with a null
+            // access, for the sin of moving the mouse.
+            stopCurrent();
+            return;
+        }
+
         createToolTip();
 
         _toolTip.hide();
 
-        var options = _toolTipOptions.get(component);
         var renderer = createToolTipRenderer(options);
         if (_toolTip.childComponents[0] != renderer) {
             if (_toolTip.childComponents.length > 0) {


### PR DESCRIPTION
`height: auto` was only ever measured as the user typed, from the change handler, so a text area filled in by the application opened at whatever height the layout had given it and stayed there. The measurement is now taken during validation as well - after the pass that lays the text out, which is the first moment there is a real height to read - so an auto height follows the text however the text arrived.

`max-height` is also honoured rather than merely stopping the growth: the old code left the height at whatever it had already reached once the next step would have passed the maximum, so a box could sit well short of the maximum it was given. It is now clamped to it, and the rest of the text scrolls.

Both callers share one implementation.