### PR TITLE
Fix marginBottom/marginRight ignored by VerticalLayout/HorizontalLayout sibling spacing

### DIFF
--- a/haxe/ui/layouts/HorizontalLayout.hx
+++ b/haxe/ui/layouts/HorizontalLayout.hx
@@ -75,7 +75,7 @@ class HorizontalLayout extends DefaultLayout {
             else {
                 child.moveComponent(xpos + marginLeft(child), ypos);
             }
-            xpos += child.componentWidth + spacing;
+            xpos += child.componentWidth + marginLeft(child) + marginRight(child) + spacing;
         }
     }
 

--- a/haxe/ui/layouts/VerticalLayout.hx
+++ b/haxe/ui/layouts/VerticalLayout.hx
@@ -34,7 +34,7 @@ class VerticalLayout extends DefaultLayout {
             }
 
             child.moveComponent(xpos, ypos + marginTop(child));
-            ypos += child.componentHeight + verticalSpacing;
+            ypos += child.componentHeight + marginTop(child) + marginBottom(child) + verticalSpacing;
         }
     }
 


### PR DESCRIPTION
## Problem

In `VerticalLayout.repositionChildren`, a child's `marginTop` is applied only when positioning that child, but the `ypos` cursor used for the *next* sibling is advanced by `componentHeight + verticalSpacing` alone:

```haxe
child.moveComponent(xpos, ypos + marginTop(child));
ypos += child.componentHeight + verticalSpacing;
```

This means:
- `margin-bottom` on a child has **no visible effect** on spacing to the next sibling (it's accounted for in `get_usableSize()`, which only affects the space reserved for percent-sized children, not sibling positions).
- `margin-top` on a child visually pushes that child down, but since it isn't folded back into `ypos`, the *following* sibling can overlap into that margin.

`HorizontalLayout.repositionChildren` has the same issue with `marginLeft`/`marginRight` and `xpos`.

## Repro

Minimal XML (any backend, e.g. haxeui-html5):

```xml
<vbox width="200">
    <button text="A" style="margin-bottom: 40px;" />
    <button text="B" />
</vbox>
```

Expected: 40px gap between A and B.
Actual (before fix): B renders immediately below A, no gap.

Swapping to `style="margin-top: 40px;"` on B produces a gap, but a version with two same-size children each carrying non-zero margins shows the accumulation error (next sibling starting position doesn't account for the previous child's total margin).

## Fix

Fold the current child's margin (both leading and trailing) into the cursor advance, so it's consistently reflected in the next sibling's position:

```haxe
// VerticalLayout
ypos += child.componentHeight + marginTop(child) + marginBottom(child) + verticalSpacing;

// HorizontalLayout
xpos += child.componentWidth + marginLeft(child) + marginRight(child) + spacing;
```

Verified in a real app: a `vbox` with a `margin-bottom` styled child (checkbox followed by a button) now renders the expected gap, matching the same fix applied via `margin-top` on the following sibling.