### PR TITLE
Fix calcAutoSize() shrinking auto-width/height by a child's own left/top margin

### DIFF
--- a/haxe/ui/layouts/Layout.hx
+++ b/haxe/ui/layouts/Layout.hx
@@ -323,19 +323,19 @@ class Layout implements ILayout {
 
             if (child.percentWidth == null) {
                 if (child.left < x1) {
-                    x1 = child.left - marginLeft(child) + marginRight(child);
+                    x1 = child.left - marginLeft(child);
                 }
                 if (child.componentWidth != null && child.left + child.componentWidth > x2) {
-                    x2 = child.left + child.componentWidth - marginLeft(child) + marginRight(child);
+                    x2 = child.left + child.componentWidth + marginRight(child);
                 }
             }
 
             if (child.percentHeight == null) {
                 if (child.top < y1) {
-                    y1 = child.top - marginTop(child) + marginBottom(child);
+                    y1 = child.top - marginTop(child);
                 }
                 if (child.componentHeight != null && child.top + child.componentHeight > y2) {
-                    y2 = child.top + child.componentHeight - marginTop(child) + marginBottom(child);
+                    y2 = child.top + child.componentHeight + marginBottom(child);
                 }
             }
         }


### PR DESCRIPTION
## Problem

`Layout.calcAutoSize()` (used by any auto-sized container to size itself around its children) computes the right/bottom bound of each child as:

```haxe
x2 = child.left + child.componentWidth - marginLeft(child) + marginRight(child);
```

`child.left` already includes `marginLeft(child)` - `VerticalLayout`/`HorizontalLayout.repositionChildren` position a child at `paddingLeft + marginLeft(child)` (or the vertical equivalent). Subtracting `marginLeft(child)` again here shrinks the computed auto-width by exactly that amount whenever a child has an asymmetric margin (`margin-left` set, `margin-right` not, which is the common case for indented list/menu items). The left bound (`x1`) has the mirrored mistake, adding `marginRight(child)` instead of leaving it alone. `y1`/`y2` have the same pattern with `marginTop`/`marginBottom`.

## Repro

Minimal XML (any backend, e.g. haxeui-html5) - an auto-sized `vbox` around a single indented label:

```xml
<vbox>
    <label text="Open Challenges" style="margin-left: 30px;" />
</vbox>
```

Expected: the vbox's auto width = the label's natural text width + 30px (its left margin).
Actual (before fix): the vbox's auto width = the label's natural text width only - the 30px margin isn't reflected in the container's size at all, so the label visually overflows past the container's right edge by 30px.

This reproduced concretely in a real app: a mobile slide-in sidebar built from indented menu-item labels (`margin-left: 30px`, `margin-right: 0`) measured 30px narrower than its widest item, so every entry's text overflowed past the sidebar's own background/border.

## Fix

```haxe
x1 = child.left - marginLeft(child);
x2 = child.left + child.componentWidth + marginRight(child);
// same pattern for y1/y2 with marginTop/marginBottom
```

`x2` should simply extend past the child's box by the child's own `marginRight`; `x1` should retreat before it by `marginLeft`. No cross terms between the two margins.

Verified against the real sidebar case: before the fix the container measured 136px wide against a widest-item right edge of 161px (30px short, exactly the item's `margin-left`); after the fix it measures 166px, containing every item with the expected 5px padding to spare.