### PR TITLE
Respect FocusManager.enabled in the focus setter

### DIFF
--- a/haxe/ui/focus/FocusManager.hx
+++ b/haxe/ui/focus/FocusManager.hx
@@ -115,6 +115,9 @@ class FocusManager extends FocusManagerImpl {
     
     private var _lastFocuses:Map<Component, IFocusable> = new Map<Component, IFocusable>();
     private function set_focus(value:IFocusable):IFocusable {
+        if (!enabled) {
+            return value;
+        }
         if (value != null) {
             var c = cast(value, Component);
             var root = c.rootComponent;


### PR DESCRIPTION
## Bug

`FocusManager.enabled` ("whether or not to allow focus management globally") is only checked inside `buildFocusableList()`, which backs `pushView`, `onViewReady`, `focusNext`/`focusPrev`, and the `focus` *getter*. The `focus` *setter* - the one that calls `applyFocus()`/`unapplyFocus()`, which is what actually adds/removes the `:active` CSS class via `StyleFocusApplicator` - never checked it.

`InteractiveComponent.set_focus` sets `this.focus = true` directly on mouse-down (e.g. `Button.hx`'s `onMouseDown`), which routes straight through the unguarded setter. So with `FocusManager.instance.enabled = false`, a mouse click still applied the `:active` style (e.g. a button's focus outline), even though auto-focus and tab navigation were correctly suppressed.

## Fix

Guard `FocusManager.set_focus` the same way `buildFocusableList()` already is - early-return when `!enabled`.

## Repro

Pure XML alone can't isolate this since it depends on a runtime call to `FocusManager.instance.enabled = false`. Minimal repro is one XML layout plus a two-line driver:

```xml
<vbox>
    <button id="btn" text="Click me" />
</vbox>
```

```haxe
haxe.ui.focus.FocusManager.instance.enabled = false;
haxe.ui.focus.FocusManager.instance.autoFocus = false;
```

Click the button. Expected: no `:active` styling. Actual (pre-fix): button gets `:active` and its focus outline, identical to when `enabled == true`.